### PR TITLE
calibration: cleanup-commit reference analysis (PR-A)

### DIFF
--- a/calibration/analysis/cleanup-commits-analysis.md
+++ b/calibration/analysis/cleanup-commits-analysis.md
@@ -1,0 +1,88 @@
+# Cleanup-commit reference dataset
+
+Per the user's tip: a merged PR's commits are themselves a calibration signal. **First commit** of a PR is the proposal; **non-first commits** that match cleanup/follow-up patterns indicate the proposal wasn't merge-ready. If our calibrated gate would have caught the issue at first-push time, that's positive validation. If not, it's a calibration gap.
+
+## Method
+
+`calibration/analyze_cleanup_commits.py`:
+1. For every measured merged PR (42 PRs across 8 repos, see `calibration/findings/prs/`), fetch its commit list via `gh api repos/<o>/<r>/pulls/<n>/commits`.
+2. Drop the first commit (the proposal).
+3. Match remaining commit messages against a cleanup regex covering: `address (review|comments?|feedback)`, `apply suggestions`, `cr feedback`, `nit(s)?`, `fix (typo|tests?|lint|ci|build|formatting|style|spelling)`, `lint`, `format`, `prettier`, `cleanup`, `tidy`, `polish`, `oops`, `whoops`, `oversight`, `revert`, `pr feedback`, `per (review|comments?|cr)`, `as per (review|comments?)`, `requested changes?`, `regen(erate)?`, `update snapshots?`.
+
+Output: `calibration/findings/cleanup_commits.json`.
+
+## Results
+
+| Metric | Value |
+|---|---|
+| PRs analyzed | 42 |
+| PRs with at least one non-first cleanup commit | 5 |
+| Cleanup commits total | 6 |
+| Cleanup-PR rate | **11.9 %** |
+
+5 PRs flagged:
+
+| Repo | PR | Total commits | Cleanup | Notes |
+|---|---|---|---|---|
+| fastapi | 15165 | 5 | 1 | bot-pushed `🎨 Auto format` after merge of translation update |
+| fastapi | 15172 | 6 | 1 | bot-pushed `🎨 Auto format` after merge of translation update |
+| fastapi | 15316 | 31 | 1 | author-pushed `Revert "Introduce issue to test zizmor"` (intentional probe removal) |
+| nextjs | 93285 | 3 | 2 | author-pushed `tweaks from PR feedback` and `check tag existence before cleanup` |
+| pydantic | 13081 | 2 | 1 | author-pushed `tidy up accessor type aliases` (Rust type-alias trim, -19 lines) |
+
+## Per-PR diff inspection
+
+### fastapi pr-15165 / 15172 — bot auto-format
+
+The cleanup commit is mechanical: a CI bot ran a formatter and pushed the result. **Calibration relevance: minor.** The gate's `no-quality-escapes` and `risk-calibrated-bloat` detectors don't measure formatting drift; this is the formatter's job, not the gate's. Out of scope.
+
+### fastapi pr-15316 — author-revert during security-tooling integration
+
+Author intentionally added a probe issue (`zizmor`-test artifact) and reverted it before the final state. **Not a calibration target** — this is iterative authoring, not response to review.
+
+### nextjs pr-93285 — author-pushed PR feedback
+
+Cleanup commit `b7bcd9c7` titled `tweaks from PR feedback`. Inspecting the diff via `gh api repos/vercel/next.js/commits/b7bcd9c7`:
+
+- `scripts/release-github-api.js`: converted positional args → object destructuring (`createTreeFromLocalCommit({ token, baseSha, localReleaseSha })`).
+- `scripts/start-release.js`: replaced `stdio: 'pipe'` + manual `child.stdout?.pipe(process.stdout)` with `stdio: 'inherit'`.
+
+**Calibration relevance: zero.** Both changes are stylistic preference. The gate is not designed to surface "use object destructuring instead of positional args" or "use inherit stdio." These are the kind of feedback that humans give that the gate's posture explicitly avoids prescribing — see CLAUDE.md operating principle "Match existing style, even if you'd do it differently."
+
+### pydantic pr-13081 — author self-tidy of Rust type aliases
+
+Cleanup commit `f20a472e` titled `tidy up accessor type aliases`. Diff: removed two `pub type ScopedFieldNameState<...>` and `ScopedDataState<...>` declarations in `validation_state.rs`. Net -19 lines.
+
+**Calibration relevance: high.** This is exactly the abstraction-sniff target shape — a type alias introduced for "extension" or "abstraction" reasons that the author later realized was unnecessary. **However:** the gate's existing `DESIGN_RE` only matches `class \w*(Factory|Builder|Manager|Registry|Strategy|Adapter|Provider)` — Rust type aliases don't match. Same blind spot as **FN-2 (Go factory regex)** but for Rust.
+
+This adds a recommendation:
+
+**FN-6 — Rust type-alias abstraction blind spot.** Extend `DESIGN_RE` with `\bpub\s+type\s+\w*(State|Manager|Strategy|Adapter|Provider|Factory|Builder|Registry|Context|Scope|Mode|Config|Options|Settings)\b` for Rust. (And the equivalent Go `type Foo<X>` pattern.) Defer to the same PR that fixes FN-2.
+
+## What the calibration gate would have caught vs. not
+
+Across the 6 cleanup commits in 5 PRs:
+
+| # | Source | What the cleanup did | Caught by calibrated gate? |
+|---|---|---|---|
+| 1 | fastapi 15165 / 15172 | format-only bot push | No — outside gate scope |
+| 2 | fastapi 15316 | self-revert of test probe | No — iterative authoring |
+| 3 | nextjs 93285 stdio | stylistic simplification | No — stylistic |
+| 4 | nextjs 93285 args | positional → destructuring | No — stylistic |
+| 5 | nextjs 93285 tag check | added tag-existence guard | No — defensive logic the author added |
+| 6 | pydantic 13081 type aliases | removed unnecessary type aliases | **Would catch** with FN-2/FN-6 fix in PR-8 (Rust extension to DESIGN_RE) |
+
+**Headline:** of the 5 cleanup-flagged PRs across 8 production repos, 1 cleanup commit (16.7%) maps to a calibration target the proposed PR-8 would address (Rust type-alias abstraction sniffing). The other 4 are formatter/stylistic/defensive — explicitly outside the gate's design scope.
+
+## Bias / scope notes
+
+- **Sample size**: 42 PRs is small. The 11.9% cleanup-PR rate may not generalize.
+- **Bot-author noise**: Dependabot/translation-bot PRs distort the denominator by inflating the "single-commit PR" share. Filtering bot-authored PRs as we did during measurement reduces but doesn't eliminate this.
+- **Regex limitations**: cleanup commits without standardized message wording (e.g., the author silently fixes a typo and commits with `change xxx`) are missed. The 11.9% is therefore a **lower bound**, not a precise estimate.
+- **No reviewer-comment correlation**: this analysis only looks at commit messages. A richer pass would correlate cleanup commits to GitHub review comments via `repos/<o>/<r>/issues/<n>/comments` and check whether the review thread mentions the symptom. Out of scope for this iteration.
+
+## Recommendation summary
+
+1. **Add FN-6 to PR-8 scope**: extend `DESIGN_RE` with Rust `pub type X = ...` patterns, alongside Go's `func NewXFactory(...)` (FN-2). One regex addition; one new test.
+2. **The cleanup-commit dataset confirms the calibration's posture**: most cleanup is style/iteration, which is correctly outside the gate's design. The gate's job is to catch the calibrated FP/FN classes, not to mediate stylistic preference.
+3. **Future calibration cycles** can integrate the cleanup-commit signal as an automatic feedback loop: after each gate change, re-run the analysis, and any new cleanup-commit class that appears (e.g., reviewers asking for a pattern the gate missed) becomes the next calibration target. This is the autonomous-loop spirit of `karpathy/autoresearch`.

--- a/calibration/analyze_cleanup_commits.py
+++ b/calibration/analyze_cleanup_commits.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Analyze cleanup/follow-up commits across measured merged PRs.
+
+For each PR in calibration/findings/prs/<repo>/pr-N.json, fetch its commit
+list from GitHub and identify cleanup-style commits via message regex.
+A "cleanup commit" is one whose first message line matches a heuristic
+indicating the PR wasn't merge-ready from the first push.
+
+Output: calibration/findings/cleanup_commits.json
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from glob import glob
+from pathlib import Path
+
+PRS_DIR = Path("/home/prop_/projects/lean code/calibration/findings/prs")
+OUT = Path("/home/prop_/projects/lean code/calibration/findings/cleanup_commits.json")
+
+GH_FOR = {
+    "django": "django/django",
+    "fastapi": "fastapi/fastapi",
+    "pydantic": "pydantic/pydantic",
+    "typescript": "microsoft/TypeScript",
+    "nextjs": "vercel/next.js",
+    "sentry": "getsentry/sentry",
+    "aws-sdk-js": "aws/aws-sdk-js-v3",
+    "grpc": "grpc/grpc",
+}
+
+CLEANUP_RE = re.compile(
+    r"\b("
+    r"address(?:\s+(?:review|comments?|feedback))?|"
+    r"apply\s+suggestions?|"
+    r"cr\s+feedback|nit|nits|"
+    r"fix\s+(?:typo|tests?|lint|ci|build|formatting|formatter|style|spelling)|"
+    r"lint(?:\s+fix)?|format(?:ting)?|prettier|"
+    r"cleanup|tidy|polish|"
+    r"oops|whoops|oversight|"
+    r"revert|undo|"
+    r"pr\s+feedback|"
+    r"per\s+(?:review|comments?|cr)|"
+    r"as\s+per\s+(?:review|comments?)|"
+    r"requested\s+changes?|"
+    r"regen(?:erate)?(?:\s+(?:snapshots?|fixtures?|generated))?|"
+    r"update\s+snapshots?"
+    r")\b",
+    re.I,
+)
+
+
+def commits_for_pr(gh: str, pr: int) -> list[dict] | None:
+    out: list[dict] = []
+    page = 1
+    while True:
+        try:
+            r = subprocess.run(
+                ["gh", "api", f"repos/{gh}/pulls/{pr}/commits?per_page=100&page={page}"],
+                capture_output=True, text=True, timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            return None
+        if r.returncode != 0:
+            return None
+        try:
+            arr = json.loads(r.stdout)
+        except json.JSONDecodeError:
+            return None
+        if not arr:
+            break
+        out.extend(arr)
+        if len(arr) < 100:
+            break
+        page += 1
+    return out
+
+
+def main() -> int:
+    results: dict[str, list[dict]] = {}
+    total_prs = 0
+    total_with_cleanup = 0
+    total_cleanup_commits = 0
+
+    for repo in sorted(os.listdir(PRS_DIR)):
+        gh = GH_FOR.get(repo)
+        if not gh:
+            continue
+        repo_results: list[dict] = []
+        for jf in sorted(glob(str(PRS_DIR / repo / "pr-*.json"))):
+            pr = int(Path(jf).stem.replace("pr-", ""))
+            total_prs += 1
+            commits = commits_for_pr(gh, pr)
+            if commits is None:
+                repo_results.append({"pr": pr, "error": "fetch_failed"})
+                continue
+            cleanup: list[dict] = []
+            # Only count NON-FIRST commits as cleanup signal: the first commit
+            # is the proposal; later commits matching the cleanup regex are the
+            # follow-ups indicating the proposal wasn't merge-ready.
+            for c in commits[1:]:
+                msg = (c.get("commit") or {}).get("message") or ""
+                first_line = msg.splitlines()[0] if msg else ""
+                if CLEANUP_RE.search(first_line):
+                    cleanup.append({
+                        "sha": c["sha"][:8],
+                        "msg": first_line[:120],
+                        "author": (c.get("author") or {}).get("login") or "?",
+                    })
+            if cleanup:
+                total_with_cleanup += 1
+                total_cleanup_commits += len(cleanup)
+            repo_results.append({
+                "pr": pr,
+                "total_commits": len(commits),
+                "cleanup_count": len(cleanup),
+                "cleanup_commits": cleanup,
+            })
+        results[repo] = repo_results
+
+    summary = {
+        "totals": {
+            "prs_analyzed": total_prs,
+            "prs_with_cleanup": total_with_cleanup,
+            "cleanup_commits_total": total_cleanup_commits,
+            "cleanup_pct": round(100.0 * total_with_cleanup / max(1, total_prs), 1),
+        },
+        "by_repo": results,
+    }
+    OUT.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps(summary["totals"], indent=2))
+    print(f"wrote {OUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/calibration/analyze_cleanup_commits.py
+++ b/calibration/analyze_cleanup_commits.py
@@ -18,8 +18,9 @@ import sys
 from glob import glob
 from pathlib import Path
 
-PRS_DIR = Path("/home/prop_/projects/lean code/calibration/findings/prs")
-OUT = Path("/home/prop_/projects/lean code/calibration/findings/cleanup_commits.json")
+_HERE = Path(__file__).resolve().parent
+PRS_DIR = _HERE / "findings" / "prs"
+OUT = _HERE / "findings" / "cleanup_commits.json"
 
 GH_FOR = {
     "django": "django/django",

--- a/calibration/findings/cleanup_commits.json
+++ b/calibration/findings/cleanup_commits.json
@@ -1,0 +1,313 @@
+{
+  "totals": {
+    "prs_analyzed": 42,
+    "prs_with_cleanup": 5,
+    "cleanup_commits_total": 6,
+    "cleanup_pct": 11.9
+  },
+  "by_repo": {
+    "aws-sdk-js": [
+      {
+        "pr": 7957,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 7958,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 7964,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 7965,
+        "total_commits": 2,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 7968,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      }
+    ],
+    "django": [
+      {
+        "pr": 21136,
+        "total_commits": 3,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 21150,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 21152,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 21177,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 21178,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      }
+    ],
+    "fastapi": [
+      {
+        "pr": 15165,
+        "total_commits": 5,
+        "cleanup_count": 1,
+        "cleanup_commits": [
+          {
+            "sha": "9cf6205c",
+            "msg": "\ud83c\udfa8 Auto format",
+            "author": "github-actions[bot]"
+          }
+        ]
+      },
+      {
+        "pr": 15172,
+        "total_commits": 6,
+        "cleanup_count": 1,
+        "cleanup_commits": [
+          {
+            "sha": "383f2c66",
+            "msg": "\ud83c\udfa8 Auto format",
+            "author": "github-actions[bot]"
+          }
+        ]
+      },
+      {
+        "pr": 15274,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 15280,
+        "total_commits": 2,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 15316,
+        "total_commits": 31,
+        "cleanup_count": 1,
+        "cleanup_commits": [
+          {
+            "sha": "0e1f26b2",
+            "msg": "Revert \"Introduce issue to test zizmor\"",
+            "author": "YuriiMotov"
+          }
+        ]
+      },
+      {
+        "pr": 15436,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 15439,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      }
+    ],
+    "grpc": [
+      {
+        "pr": 42124,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 42144,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 42159,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 42215,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 42221,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      }
+    ],
+    "nextjs": [
+      {
+        "pr": 93235,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 93236,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 93241,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 93245,
+        "total_commits": 4,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 93285,
+        "total_commits": 3,
+        "cleanup_count": 2,
+        "cleanup_commits": [
+          {
+            "sha": "f5ebf3b7",
+            "msg": "check tag existence before cleanup",
+            "author": "ztanner"
+          },
+          {
+            "sha": "b7bcd9c7",
+            "msg": "tweaks from PR feedback",
+            "author": "ztanner"
+          }
+        ]
+      }
+    ],
+    "pydantic": [
+      {
+        "pr": 13081,
+        "total_commits": 2,
+        "cleanup_count": 1,
+        "cleanup_commits": [
+          {
+            "sha": "f20a472e",
+            "msg": "tidy up accessor type aliases",
+            "author": "davidhewitt"
+          }
+        ]
+      },
+      {
+        "pr": 13084,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 13096,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 13098,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 13108,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      }
+    ],
+    "sentry": [
+      {
+        "pr": 114077,
+        "total_commits": 2,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 114084,
+        "total_commits": 3,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 114088,
+        "total_commits": 5,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 114097,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 114099,
+        "total_commits": 6,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      }
+    ],
+    "typescript": [
+      {
+        "pr": 63366,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 63368,
+        "total_commits": 2,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 63372,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 63401,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      },
+      {
+        "pr": 63407,
+        "total_commits": 1,
+        "cleanup_count": 0,
+        "cleanup_commits": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Follow-up on the user's tip: use a merged PR's commit list as calibration signal. Non-first commits matching a cleanup/follow-up regex indicate the proposal wasn't merge-ready from the first push.

**Stacked on PR #3** (calibration/policy) because it depends on `calibration/findings/prs/`.

## Method
`calibration/analyze_cleanup_commits.py`:
1. For each of the 42 measured merged PRs, fetch commit list via `gh api`.
2. Drop the first commit (the proposal).
3. Match remaining messages against a heuristic cleanup regex.

## Headline result
| Metric | Value |
|---|---|
| PRs analyzed | 42 |
| PRs with non-first cleanup commit | 5 |
| Cleanup commits total | 6 |
| Cleanup-PR rate | **11.9%** |

## Per-commit verdict (full inspection in `cleanup-commits-analysis.md`)
- 4 of 6 cleanup commits: formatter/stylistic/defensive — outside the gate's design scope per CLAUDE.md "match existing style, even if you'd do it differently".
- 1 of 6 (pydantic pr-13081): removed two Rust `pub type X = ...` declarations the author later realized were unnecessary abstraction. **Adds FN-6**: extend `DESIGN_RE` to catch Rust type-alias abstraction alongside Go's `func New*Factory(...)` (FN-2). Slated for PR-8.

## Files
- `calibration/analyze_cleanup_commits.py` — runner.
- `calibration/findings/cleanup_commits.json` — full per-PR data.
- `calibration/analysis/cleanup-commits-analysis.md` — analysis with per-commit verdicts.

## Conclusion
The cleanup-commit dataset confirms the calibration posture. Most cleanup is iteration/style that the gate correctly stays out of; the one calibration-relevant case (Rust type aliases) is already on the PR-8 scope expansion list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/future3ooo/lean-code-gate-v3/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
