### PR TITLE
gate: add excluded_path_globs policy field (PR-5, R-1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 LEAN_CODE_GATE_V3_CALIBRATION_GUIDE.md
 *:Zone.Identifier
 .claude/
+/.agent/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 LEAN_CODE_GATE_V3_CALIBRATION_GUIDE.md
 *:Zone.Identifier
 .claude/
-/.agent/

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1000,8 +1000,16 @@ def is_excluded_path(path: str) -> bool:
     lowered = f"/{norm_path(path).lower()}"
     if any(marker in lowered for marker in ("/.codex/quality/logs/", "/.agent/lean/", "/logs/")):
         return True
-    normalized = norm_path(path)
-    return any(fnmatch.fnmatch(normalized, glob) for glob in _active_excluded_globs)
+    if not _active_excluded_globs:
+        return False
+    normalized = norm_path(path).lower()
+    # fnmatch treats ** as a single * (no multi-segment semantics). To match
+    # globs like "**/migrations/**" against first-component paths like
+    # "migrations/0001.py", check both the bare path and a /-prefixed variant.
+    candidates = (normalized, "/" + normalized)
+    return any(
+        fnmatch.fnmatch(c, glob.lower()) for glob in _active_excluded_globs for c in candidates
+    )
 
 
 def is_test_like_path(path: str) -> bool:
@@ -1473,11 +1481,15 @@ def changed_file_failures(repo: Path, changed_files: set[str]) -> tuple[list[str
     return conflict_files, temp_files
 
 
-def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -> dict[str, object]:
-    active_policy = policy(repo)
+def apply_active_policy(active_policy: dict[str, object]) -> None:
     global _active_excluded_globs
     raw = active_policy.get("excluded_path_globs")
     _active_excluded_globs = tuple(g for g in raw if isinstance(g, str)) if isinstance(raw, list) else ()
+
+
+def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -> dict[str, object]:
+    active_policy = policy(repo)
+    apply_active_policy(active_policy)
     ctx = collect_scope(repo, base_ref)
     changed_files = set(ctx.changed_files)
     errors: list[str] = []
@@ -1843,6 +1855,7 @@ def pretool(payload: dict[str, object]) -> None:
         return
     current_contract = contract(root)
     active_policy = policy(root)
+    apply_active_policy(active_policy)
     errors = contract_errors(current_contract, active_policy)
     if errors:
         deny("PreToolUse", "Lean Code Gate blocked mutation before contract:\n- " + "\n- ".join(errors))

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -64,6 +64,31 @@ DEFAULT_POLICY: dict[str, object] = {
     "reuse_detector_mode": "conservative",
     "reuse_error_score": 90,
     "reuse_warning_score": 45,
+    "excluded_path_globs": [
+        "**/migrations/**",
+        "**/generated/**",
+        "**/__generated__/**",
+        "**/_generated/**",
+        "**/*.pb.go",
+        "**/*.pb.cc",
+        "**/*.pb.h",
+        "**/*.pb.py",
+        "**/*_pb2.py",
+        "**/*_pb2_grpc.py",
+        "**/*.generated.*",
+        "**/dist-cjs/**",
+        "**/dist-es/**",
+        "**/dist-types/**",
+        "clients/*/src/commands/**",
+        "clients/*/src/models/**",
+        "clients/*/src/schemas/**",
+        "clients/*/src/protocols/**",
+        "clients/*/src/waiters/**",
+        "**/admin/static/admin/**",
+        "**/static/admin/**",
+        "docs_src/**",
+        "**/python_version.py",
+    ],
 }
 
 MUTATING_TOOLS = {"Edit", "MultiEdit", "Write", "NotebookEdit", "apply_patch", "ApplyPatch"}
@@ -965,12 +990,18 @@ def is_binary_path(path: str) -> bool:
     return Path(path).suffix.lower() in BINARY_EXTENSIONS
 
 
+_active_excluded_globs: tuple[str, ...] = ()
+
+
 def is_excluded_path(path: str) -> bool:
     parts = [part.lower() for part in norm_path(path).split("/") if part]
     if any(part in EXCLUDE_DIRS for part in parts):
         return True
     lowered = f"/{norm_path(path).lower()}"
-    return any(marker in lowered for marker in ("/.codex/quality/logs/", "/.agent/lean/", "/logs/"))
+    if any(marker in lowered for marker in ("/.codex/quality/logs/", "/.agent/lean/", "/logs/")):
+        return True
+    normalized = norm_path(path)
+    return any(fnmatch.fnmatch(normalized, glob) for glob in _active_excluded_globs)
 
 
 def is_test_like_path(path: str) -> bool:
@@ -1444,6 +1475,9 @@ def changed_file_failures(repo: Path, changed_files: set[str]) -> tuple[list[str
 
 def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -> dict[str, object]:
     active_policy = policy(repo)
+    global _active_excluded_globs
+    raw = active_policy.get("excluded_path_globs")
+    _active_excluded_globs = tuple(g for g in raw if isinstance(g, str)) if isinstance(raw, list) else ()
     ctx = collect_scope(repo, base_ref)
     changed_files = set(ctx.changed_files)
     errors: list[str] = []

--- a/lean-code-gate-v3/.agent/lean/policy.json
+++ b/lean-code-gate-v3/.agent/lean/policy.json
@@ -35,5 +35,30 @@
   "quality_max_index_symbols": 25000,
   "reuse_detector_mode": "conservative",
   "reuse_error_score": 90,
-  "reuse_warning_score": 45
+  "reuse_warning_score": 45,
+  "excluded_path_globs": [
+    "**/migrations/**",
+    "**/generated/**",
+    "**/__generated__/**",
+    "**/_generated/**",
+    "**/*.pb.go",
+    "**/*.pb.cc",
+    "**/*.pb.h",
+    "**/*.pb.py",
+    "**/*_pb2.py",
+    "**/*_pb2_grpc.py",
+    "**/*.generated.*",
+    "**/dist-cjs/**",
+    "**/dist-es/**",
+    "**/dist-types/**",
+    "clients/*/src/commands/**",
+    "clients/*/src/models/**",
+    "clients/*/src/schemas/**",
+    "clients/*/src/protocols/**",
+    "clients/*/src/waiters/**",
+    "**/admin/static/admin/**",
+    "**/static/admin/**",
+    "docs_src/**",
+    "**/python_version.py"
+  ]
 }

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -469,6 +469,29 @@ def test_large_existing_file_big_growth_fails() -> None:
         assert data["hardRules"]["codeVolume"]["passed"] is False
 
 
+def test_excluded_path_globs_skip_generated_sdk_files() -> None:
+    with repo_fixture() as repo:
+        (repo / "clients" / "client-test" / "src" / "commands").mkdir(parents=True)
+        big = "\n".join(f"export const CMD_{i} = {{}};" for i in range(900))
+        (repo / "clients" / "client-test" / "src" / "commands" / "BigCmd.ts").write_text(big + "\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert all("clients/client-test/src/commands/BigCmd.ts" not in error for error in data["errors"])
+
+
+def test_excluded_path_globs_can_be_overridden_to_empty() -> None:
+    with repo_fixture() as repo:
+        (repo / ".agent" / "lean" / "policy.json").write_text(
+            json.dumps({"excluded_path_globs": []}), encoding="utf-8"
+        )
+        (repo / "clients" / "client-test" / "src" / "commands").mkdir(parents=True)
+        big = "\n".join(f"export const CMD_{i} = {{}};" for i in range(900))
+        (repo / "clients" / "client-test" / "src" / "commands" / "BigCmd.ts").write_text(big + "\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 2, data
+        assert any("clients/client-test/src/commands/BigCmd.ts" in error for error in data["errors"])
+
+
 def test_gate_check_creates_no_repo_artifacts() -> None:
     with repo_fixture() as repo:
         before = snapshot_paths(repo)
@@ -502,6 +525,8 @@ TESTS = [
     test_reuse_detector_ignores_same_name_across_languages,
     test_large_existing_file_small_growth_warns_but_does_not_fail_by_default,
     test_large_existing_file_big_growth_fails,
+    test_excluded_path_globs_skip_generated_sdk_files,
+    test_excluded_path_globs_can_be_overridden_to_empty,
     test_gate_check_creates_no_repo_artifacts,
 ]
 

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -479,6 +479,19 @@ def test_excluded_path_globs_skip_generated_sdk_files() -> None:
         assert all("clients/client-test/src/commands/BigCmd.ts" not in error for error in data["errors"])
 
 
+def test_excluded_path_globs_match_first_component_path() -> None:
+    # Regression: fnmatch treats ** as a single *, so "**/migrations/**" must
+    # also match a path whose FIRST component is the excluded directory
+    # (e.g. "migrations/0001_initial.py"), not just nested cases.
+    with repo_fixture() as repo:
+        (repo / "migrations").mkdir()
+        big = "\n".join(f"OP_{i} = None" for i in range(900))
+        (repo / "migrations" / "0001_initial.py").write_text(big + "\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert all("migrations/0001_initial.py" not in error for error in data["errors"])
+
+
 def test_excluded_path_globs_can_be_overridden_to_empty() -> None:
     with repo_fixture() as repo:
         (repo / ".agent" / "lean" / "policy.json").write_text(
@@ -526,6 +539,7 @@ TESTS = [
     test_large_existing_file_small_growth_warns_but_does_not_fail_by_default,
     test_large_existing_file_big_growth_fails,
     test_excluded_path_globs_skip_generated_sdk_files,
+    test_excluded_path_globs_match_first_component_path,
     test_excluded_path_globs_can_be_overridden_to_empty,
     test_gate_check_creates_no_repo_artifacts,
 ]


### PR DESCRIPTION
## Summary

First gate-code change implementing the calibration program. Lands **calibration recommendation R-1** from PR #3: a policy-configurable list of `fnmatch` globs that exclude paths from all detector workloads (bloat, reuse, escapes, duplicates).

## Implementation

**3 files, +87/−2:**

- `.agent/lean/lean_code_gate.py`:
  - Module-level `_active_excluded_globs: tuple[str, ...] = ()` populated at the top of `run_quality_gate` from `policy["excluded_path_globs"]`. Resets every call (no inter-call state leakage).
  - `is_excluded_path()` now also returns `True` for any path matching one of the active globs via `fnmatch.fnmatch`.
  - `DEFAULT_POLICY` gains the field with 22 default globs covering: generated SDK code (`clients/*/src/{commands,models,schemas,protocols,waiters}/**`), protobuf output (`*.pb.{go,cc,h,py}`, `*_pb2*.py`), Smithy/codegen (`*.generated.*`, `dist-{cjs,es,types}/**`, `_generated/`, `__generated__/`, `generated/`), `migrations/`, vendored Django admin static, FastAPI `docs_src/**`, and grpc `python_version.py`.

- `.agent/lean/policy.json`: shipped defaults synced to `DEFAULT_POLICY`.

- `tests/test_lean_code_gate.py`: 2 new tests (registered in `TESTS`) pinning:
  - `test_excluded_path_globs_skip_generated_sdk_files` — defaults silence a 900-line new file under `clients/client-test/src/commands/`.
  - `test_excluded_path_globs_can_be_overridden_to_empty` — override to `[]` restores v3.0.0 behavior.

## Backward compatibility

When policy lacks the key (or sets a non-list), `_active_excluded_globs` resolves to an empty tuple and `is_excluded_path` is byte-identical to v3.0.0. Existing 23 tests remain green.

## Lean Change Contract

Declared 2026-04-28 with full preflight (intent / scope / affected-surface / contract / invariants / reuse-path / proof-plan / risk-check / verify). Dogfooded.

## Verification

```
$ python3 lean-code-gate-v3/tests/test_lean_code_gate.py
passed 25 lean-code-gate tests   [+2 from v3 baseline]
```

## Calibration evidence (full rationale in `calibration/analysis/policy-recommendations.md` R-1)

| repo | finding | now silenced |
|---|---|---|
| aws-sdk-js | 18 bloat errors / 91 warnings, ~100% in `clients/*/src/{commands,models,schemas}/` | ✅ |
| pydantic | `pydantic-core/src/self_schema.py +6852` ("auto-generated, DO NOT edit manually") | ✅ |
| typescript | `dom.generated.d.ts`, `webworker.generated.d.ts` | ✅ |
| grpc | 14-way `python_version.py` duplicate | ✅ |
| django pr-21136 | `admin/static/admin/js/urlify.js +363` | ✅ |
| fastapi pr-15280 | `docs_src/vibe/` tutorial escape | ✅ |

## Notes

Following user's standing rules: not self-merging; awaiting review. Bot feedback will be triaged (verify against current source; act on real issues, decline incorrect ones in-thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/future3ooo/lean-code-gate-v3/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now configure path exclusions through glob patterns in policy settings, excluding specific files and directories from quality gate analysis. The feature supports flexible pattern matching for generated SDKs, database migrations, protobuf files, bundled distributions, and other paths, with exclusion rules consistently applied throughout all quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->