### PR TITLE
gate: bloat threshold + min duplicate count + Go/Rust factory regex (PR-8)

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -197,6 +197,10 @@ HIDDEN_WRITE_RE = re.compile(
 DESIGN_RE = [
     (re.compile(r"\bclass\s+\w*(Factory|Builder|Manager|Registry|Strategy|Adapter|Provider)\b"), "pattern-named class"),
     (re.compile(r"\bfunc\s+(?:\([^)]*\)\s*)?New\w*(Factory|Builder|Manager|Registry|Strategy|Adapter|Provider)\b"), "pattern-named factory function"),
+    # Rust pattern intentionally broader than Python/JS (State/Context/Scope
+    # added). Rust's type-alias system is commonly used for abstraction
+    # layering (e.g., pub type ParserState, pub type RequestContext) in ways
+    # the Python/JS class pattern isn't. Asymmetry is calibrated, not a bug.
     (re.compile(r"\bpub\s+type\s+\w*(State|Manager|Strategy|Adapter|Provider|Factory|Builder|Registry|Context|Scope)\b"), "rust type-alias abstraction"),
     (re.compile(r"\b(Abstract[A-Z]\w*|Base[A-Z]\w*)\b"), "abstract/base type"),
     (re.compile(r"\b(Protocol|ABC|abc\.ABC|TypeVar|Generic\[)\b"), "generic typing abstraction"),

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -51,7 +51,7 @@ DEFAULT_POLICY: dict[str, object] = {
     "allowed_broad_globs": ["src/**", "lib/**", "app/**", "tests/**", "test/**"],
     "bloat_new_file_warn_lines": 500,
     "bloat_new_file_error_lines": 800,
-    "bloat_large_file_lines": 1200,
+    "bloat_large_file_lines": 1500,
     "bloat_large_file_must_shrink": False,
     "bloat_large_file_growth_lines": 80,
     "bloat_file_growth_lines": 250,
@@ -65,6 +65,7 @@ DEFAULT_POLICY: dict[str, object] = {
     "reuse_detector_mode": "conservative",
     "reuse_error_score": 90,
     "reuse_warning_score": 45,
+    "reuse_min_duplicate_count": 3,
     "reuse_suppress_private_public_siblings": True,
     "framework_override_names": [
         "validate", "clean", "save", "save_model", "save_formset",
@@ -195,6 +196,8 @@ HIDDEN_WRITE_RE = re.compile(
 )
 DESIGN_RE = [
     (re.compile(r"\bclass\s+\w*(Factory|Builder|Manager|Registry|Strategy|Adapter|Provider)\b"), "pattern-named class"),
+    (re.compile(r"\bfunc\s+(?:\([^)]*\)\s*)?New\w*(Factory|Builder|Manager|Registry|Strategy|Adapter|Provider)\b"), "pattern-named factory function"),
+    (re.compile(r"\bpub\s+type\s+\w*(State|Manager|Strategy|Adapter|Provider|Factory|Builder|Registry|Context|Scope)\b"), "rust type-alias abstraction"),
     (re.compile(r"\b(Abstract[A-Z]\w*|Base[A-Z]\w*)\b"), "abstract/base type"),
     (re.compile(r"\b(Protocol|ABC|abc\.ABC|TypeVar|Generic\[)\b"), "generic typing abstraction"),
     (re.compile(r"\b(plugin|middleware|strategy|extensible|extension point|feature[_ -]?flag)\b", re.I), "extension machinery"),
@@ -1012,6 +1015,7 @@ def is_binary_path(path: str) -> bool:
 _active_excluded_globs: tuple[str, ...] = ()
 _active_framework_override_names: frozenset[str] = frozenset()
 _active_suppress_private_public_siblings: bool = False
+_active_min_duplicate_count: int = 2
 
 
 def is_excluded_path(path: str) -> bool:
@@ -1140,7 +1144,7 @@ def duplicate_added_blocks(ctx: GateContext) -> list[dict[str, object]]:
         [
             {"count": item["count"], "files": sorted(item["files"]), "sample": item["sample"]}
             for item in windows.values()
-            if int(item["count"]) > 1 and isinstance(item["files"], set)
+            if int(item["count"]) >= _active_min_duplicate_count and isinstance(item["files"], set)
         ]
     )
 
@@ -1507,12 +1511,13 @@ def changed_file_failures(repo: Path, changed_files: set[str]) -> tuple[list[str
 
 
 def apply_active_policy(active_policy: dict[str, object]) -> None:
-    global _active_excluded_globs, _active_framework_override_names, _active_suppress_private_public_siblings
+    global _active_excluded_globs, _active_framework_override_names, _active_suppress_private_public_siblings, _active_min_duplicate_count
     raw_globs = active_policy.get("excluded_path_globs")
     _active_excluded_globs = tuple(g for g in raw_globs if isinstance(g, str)) if isinstance(raw_globs, list) else ()
     raw_names = active_policy.get("framework_override_names")
     _active_framework_override_names = frozenset(n for n in raw_names if isinstance(n, str)) if isinstance(raw_names, list) else frozenset()
     _active_suppress_private_public_siblings = bool(active_policy.get("reuse_suppress_private_public_siblings"))
+    _active_min_duplicate_count = max(2, int(active_policy.get("reuse_min_duplicate_count") or 2))
 
 
 def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -> dict[str, object]:

--- a/lean-code-gate-v3/.agent/lean/policy.json
+++ b/lean-code-gate-v3/.agent/lean/policy.json
@@ -24,7 +24,7 @@
   "bloat_new_file_warn_lines": 500,
   "bloat_new_file_error_lines": 800,
   "bloat_large_file_must_shrink": false,
-  "bloat_large_file_lines": 1200,
+  "bloat_large_file_lines": 1500,
   "bloat_large_file_growth_lines": 80,
   "bloat_file_growth_lines": 250,
   "bloat_total_added_warn_lines": 500,
@@ -37,6 +37,7 @@
   "reuse_detector_mode": "conservative",
   "reuse_error_score": 90,
   "reuse_warning_score": 45,
+  "reuse_min_duplicate_count": 3,
   "reuse_suppress_private_public_siblings": true,
   "framework_override_names": [
     "validate", "clean", "save", "save_model", "save_formset",

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -335,6 +335,11 @@ def parse_group(value: str) -> str:
     raw = value.strip()
     normalized = raw.lower()
     return normalized.replace(" ", "-")
+
+def parse_role(value: str) -> str:
+    raw = value.strip()
+    normalized = raw.lower()
+    return normalized.replace(" ", "-")
 """
         (repo / "src" / "duplicate.py").write_text(duplicate, encoding="utf-8")
         code, data = check_json(repo)
@@ -447,7 +452,7 @@ def test_reuse_detector_ignores_same_name_across_languages() -> None:
 
 def test_large_existing_file_small_growth_warns_but_does_not_fail_by_default() -> None:
     with repo_fixture() as repo:
-        (repo / "src" / "large.py").write_text("\n".join(f"VALUE_{i} = {i}" for i in range(1201)) + "\n", encoding="utf-8")
+        (repo / "src" / "large.py").write_text("\n".join(f"VALUE_{i} = {i}" for i in range(1501)) + "\n", encoding="utf-8")
         git(repo, "add", ".")
         git(repo, "commit", "--no-gpg-sign", "-m", "large baseline")
         with (repo / "src" / "large.py").open("a", encoding="utf-8") as handle:
@@ -459,7 +464,7 @@ def test_large_existing_file_small_growth_warns_but_does_not_fail_by_default() -
 
 def test_large_existing_file_big_growth_fails() -> None:
     with repo_fixture() as repo:
-        (repo / "src" / "large.py").write_text("\n".join(f"VALUE_{i} = {i}" for i in range(1201)) + "\n", encoding="utf-8")
+        (repo / "src" / "large.py").write_text("\n".join(f"VALUE_{i} = {i}" for i in range(1501)) + "\n", encoding="utf-8")
         git(repo, "add", ".")
         git(repo, "commit", "--no-gpg-sign", "-m", "large baseline")
         with (repo / "src" / "large.py").open("a", encoding="utf-8") as handle:
@@ -478,6 +483,43 @@ _HIGH_DENSITY_TEXT = (
     "    plugin = True\n"
     "    pass\n"
 )
+
+
+def test_min_duplicate_count_suppresses_two_instance_hit() -> None:
+    with repo_fixture() as repo:
+        # Two identical blocks — under default reuse_min_duplicate_count=3 this
+        # MUST NOT fire; raises a calibration concern at N=2 (django pr-21152).
+        block = (
+            "def helper(x):\n"
+            "    raw = x.strip()\n"
+            "    normalized = raw.lower()\n"
+            "    return normalized.replace(\" \", \"-\")\n"
+        )
+        (repo / "src" / "twohit.py").write_text(block + "\n" + block.replace("def helper", "def helper2"), encoding="utf-8")
+        code, data = check_json(repo)
+        dup_check = next(c for c in data["checks"] if c["name"] == "no-duplicate-added-blocks")
+        assert dup_check["passed"] is True, data
+
+
+def _load_gate_module() -> object:
+    import importlib.util
+    import sys as _sys
+    spec = importlib.util.spec_from_file_location("gate_under_test", str(GATE))
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    _sys.modules["gate_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_design_re_catches_go_factory_function() -> None:
+    hits = _load_gate_module().design_hits("func NewWidgetFactory() *WidgetFactory { return nil }")
+    assert "pattern-named factory function" in hits
+
+
+def test_design_re_catches_rust_pub_type_alias() -> None:
+    hits = _load_gate_module().design_hits("pub type ScopedFieldNameState<'scope, 'a, 'py> = ScopedSetState<...>;")
+    assert "rust type-alias abstraction" in hits
 
 
 def test_pretool_blocks_high_density_abstraction_in_small_file() -> None:
@@ -616,6 +658,9 @@ TESTS = [
     test_reuse_detector_ignores_same_name_across_languages,
     test_large_existing_file_small_growth_warns_but_does_not_fail_by_default,
     test_large_existing_file_big_growth_fails,
+    test_min_duplicate_count_suppresses_two_instance_hit,
+    test_design_re_catches_go_factory_function,
+    test_design_re_catches_rust_pub_type_alias,
     test_pretool_blocks_high_density_abstraction_in_small_file,
     test_pretool_allows_low_density_abstraction_in_large_file,
     test_pretool_blocks_at_density_threshold_in_large_file,


### PR DESCRIPTION
## Summary

Final calibration code change. Implements four small items from PR #3:

- **R-4** `reuse_min_duplicate_count: 3` (was effectively 2)
- **R-5** `bloat_large_file_lines: 1200 → 1500`
- **FN-2** Extend `DESIGN_RE` with Go's `func New*Factory(...)` pattern
- **FN-6** Extend `DESIGN_RE` with Rust's `pub type X<...> = ...` pattern (from PR-A's cleanup-commit analysis)

**Stacked on PR #9** (gate/abstraction-density).

## Honest confidence breakdown

Per the user's curve-fitting concern, I want to be transparent about the evidence base behind each magnitude:

| Item | Direction supported by | Specific value supported by | Confidence |
|---|---|---|---|
| R-4 (raise from 2) | django pr-21152 (N=2 FP, reviewers shipped) | The choice of `3` (not 4 or 5): judgment | **Inferred** |
| R-5 (raise from 1200) | Django's `query.py` 2892, `query.py` 3024, `models/fields/__init__.py` 2972, `admin/options.py` 2632 | The choice of `1500` (not 1800 or 2000): judgment | **Inferred** |
| FN-2 Go factory regex | Direct gap verified against `DESIGN_RE` source (line 197) | Pattern is standard Go idiom | **Established** |
| FN-6 Rust pub type | Direct observation: pydantic pr-13081 cleanup commit removed two `pub type ScopedFieldNameState<...>` declarations | Pattern is the canonical Rust idiom | **Established (gap), Inferred (suffix list)** |

**Both R-4 and R-5 are easily overridable by projects** (every value lives in `policy.json`). Setting `reuse_min_duplicate_count: 2` restores v3.0.0 behavior; same for `bloat_large_file_lines: 1200`.

## Implementation

**3 files, +57/−7:**

- `lean-code-gate-v3/.agent/lean/lean_code_gate.py`:
  - New module-level `_active_min_duplicate_count: int = 2`, populated from `policy["reuse_min_duplicate_count"]`. Floored at 2 (`max(2, n)`) so misconfiguration cannot fully disable detection.
  - `duplicate_added_blocks()` filter uses `>= _active_min_duplicate_count` instead of `> 1`.
  - `DEFAULT_POLICY`: `reuse_min_duplicate_count: 3`, `bloat_large_file_lines: 1500`.
  - `DESIGN_RE`: 2 new patterns.
- `lean-code-gate-v3/.agent/lean/policy.json`: shipped defaults match.
- `lean-code-gate-v3/tests/test_lean_code_gate.py`:
  - Two existing tests adjusted: large-file fixtures bumped 1201 → 1501; duplicate-block fixture grows from 2 to 3 functions to exercise the new threshold.
  - **+3 new tests** (registered): N=2 suppression, Go factory regex, Rust `pub type` regex.
  - Shared `_load_gate_module()` helper to dedupe `importlib.spec_from_file_location` across the two regex tests (was duplicated 6 lines × 2).

## Cross-PR note

PR #4 (`calibration/proposed-tests`) currently asserts that N=2 duplicates fire under v3 defaults (`test_two_instance_duplicate_currently_fires`). That test was a *behavior pin* for the pre-calibration state. **It will need a small follow-up update once this PR lands** — will be addressed via a commit on PR #4 after merge order is resolved.

## Verification

```
$ python3 lean-code-gate-v3/tests/test_lean_code_gate.py
passed 32 lean-code-gate tests   [+3 from PR-7 baseline]
```

## Notes

Following user's standing rules: not self-merging; awaiting review. Bot feedback will be triaged against current source (verify before acting; decline incorrect ones in-thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/future3ooo/lean-code-gate-v3/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
