### PR TITLE
gate: tolerate non-utf-8 bytes in subprocess output (PR-E, gate-bug-1 fix)

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -466,12 +466,17 @@ class GateContext:
 
 def run_process(cmd: list[str], cwd: Path, timeout: int = 15) -> subprocess.CompletedProcess[str]:
     try:
+        # text=True implies strict utf-8 decoding which crashes when git diff
+        # output contains non-utf-8 bytes (e.g. binary patches in long
+        # multi-commit windows). Use encoding+errors='replace' instead so
+        # the gate can keep running and just lose offending bytes.
         process = subprocess.Popen(
             cmd,
             cwd=str(cwd),
-            text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            encoding="utf-8",
+            errors="replace",
             start_new_session=(os.name != "nt"),
         )
         stdout, stderr = process.communicate(timeout=timeout)

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -512,6 +512,23 @@ def _load_gate_module() -> object:
     return mod
 
 
+def test_run_process_tolerates_non_utf8_output() -> None:
+    # Regression: subprocess.Popen(text=True) decodes with strict utf-8 and
+    # crashes on non-utf-8 bytes (surfaced by gate.py running git diff over
+    # a 100-commit TypeScript window with binary patches). The fixed
+    # run_process uses errors='replace' so non-utf-8 bytes become �
+    # rather than raising UnicodeDecodeError.
+    mod = _load_gate_module()
+    with tempfile.TemporaryDirectory() as tmp:
+        result = mod.run_process(
+            ["python3", "-c", r"import sys; sys.stdout.buffer.write(b'hello \xc3\x28 world')"],
+            Path(tmp),
+        )
+        assert result.returncode == 0, result.stderr
+        # \xc3\x28 is invalid utf-8; with errors='replace' it becomes �
+        assert "hello" in result.stdout and "world" in result.stdout
+
+
 def test_high_confidence_reuse_respects_r2_r3_suppression() -> None:
     # Regression: high_confidence_reuse used to duplicate same_behavior_name's
     # name+token check and bypass R-2/R-3 suppression. Surfaced in calibration
@@ -678,6 +695,7 @@ TESTS = [
     test_large_existing_file_small_growth_warns_but_does_not_fail_by_default,
     test_large_existing_file_big_growth_fails,
     test_min_duplicate_count_suppresses_two_instance_hit,
+    test_run_process_tolerates_non_utf8_output,
     test_high_confidence_reuse_respects_r2_r3_suppression,
     test_design_re_catches_go_factory_function,
     test_design_re_catches_rust_pub_type_alias,


### PR DESCRIPTION
## Summary

Fixes **gate-bug-1** that PR-C's validation cycle (A4) surfaced.

In the within-repo holdout run on TypeScript with \`HEAD~99..HEAD\` (~100-commit diff window), the gate crashed with:

\`\`\`
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x92 in position 88959088: invalid start byte
\`\`\`

Root cause: \`subprocess.Popen(..., text=True)\` decodes stdout/stderr with strict UTF-8. Git diff output over a long window can include binary patches with non-UTF-8 bytes; strict decoding crashes.

## Fix

Replace \`text=True\` with explicit \`encoding="utf-8", errors="replace"\`:

\`\`\`python
process = subprocess.Popen(
    cmd,
    cwd=str(cwd),
    stdout=subprocess.PIPE,
    stderr=subprocess.PIPE,
    encoding="utf-8",
    errors="replace",
    start_new_session=(os.name != "nt"),
)
\`\`\`

Bad bytes become the Unicode replacement character (\`\\ufffd\`) rather than crashing. Detector regexes don't match replacement chars, so behavior on clean diffs is unchanged.

## Regression test

\`test_run_process_tolerates_non_utf8_output\` (registered in TESTS): spawns a Python that emits \`b"hello \\xc3\\x28 world"\` (invalid 2-byte UTF-8 sequence) via stdout and asserts \`run_process\` returns rc=0 with both \"hello\" and \"world\" present in the decoded stdout. Pre-fix this test would have raised UnicodeDecodeError.

## Verification

\`\`\`
$ python3 lean-code-gate-v3/tests/test_lean_code_gate.py
passed 36 lean-code-gate tests   [+1 from PR-D]
\`\`\`

## Stacked on PR-D (#13)

Branches off \`gate/fix-high-confidence-reuse\`. PR-D + PR-E together address both bugs found by the validation cycle.

## Notes

Following user's standing rules: not self-merging; awaiting review.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/future3ooo/lean-code-gate-v3/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
