### PR TITLE
gate: document quality-escape path-filter asymmetry vs other detectors

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1111,6 +1111,18 @@ def multiline_hits(path: str, text: str) -> list[str]:
 
 
 def scan_quality_escapes(ctx: GateContext) -> list[str]:
+    # Path filter is is_source_path (not is_production_source_path) by design.
+    # Reuse/duplicate/bloat detectors filter to is_production_source_path
+    # because their findings are scoped to the new code's relationship to
+    # the production codebase. Quality-escape's path filter is broader so
+    # GENERAL_ESCAPE_RULES (TODO/FIXME, # type: ignore, @ts-ignore,
+    # eslint-disable, # noqa, || true) catches escapes in test/fixture
+    # paths too — those locations are particularly prone to vestigial
+    # suppressions (Wen et al. FSE 2025: 50.8% of suppressions are useless).
+    # Language-typed rules (PYTHON_ESCAPE_RULES, TS_ESCAPE_RULES — `: Any`,
+    # `as any`, bare `except:`) DO restrict to production via
+    # is_production_source_path inside rules_for_path; mocks in tests
+    # legitimately use `as any` and shouldn't trip this layer.
     hits: list[str] = []
     for rel_path, lines in ctx.added_lines.items():
         if is_source_path(rel_path):


### PR DESCRIPTION
## Summary

- The calibration parity analysis (A19, see [lean-code-gate-calibration](https://github.com/future3OOO/lean-code-gate-calibration)) flagged that \`scan_quality_escapes\` uses \`is_source_path\` while reuse, duplicate-block, and bloat detectors use \`is_production_source_path\`. Adversarial fixture \`escape_in_test_file_should_not_fire\` triggered on \`tests/test_x.py:1\` with \`# type: ignore\`, while equivalent reuse fixtures are filtered at the test path.
- **Investigation conclusion: the asymmetry is intentional, not a bug.** The fix is to document it, not change behavior.

## Why intentional

\`GENERAL_ESCAPE_RULES\` (TODO/FIXME, \`# type: ignore\`, \`@ts-ignore\`, \`eslint-disable\`, \`# noqa\`, \`|| true\`) are language-agnostic markers that should fire everywhere — Wen et al., FSE 2025 ([An Empirical Study of Suppressed Static Analysis Warnings](https://software-lab.org/publications/fse2025_suppressions.pdf)) reports **50.8% of suppressions are useless** and accumulate over project lifetime. Test files are particularly prone to harboring vestigial ones. Catching them in tests is a feature.

Language-specific \`PYTHON_ESCAPE_RULES\` (\`: Any\`, \`cast(\`, bare \`except:\`) and \`TS_ESCAPE_RULES\` (\`: any\`, \`as any\`, \`as unknown as\`) DO restrict to production via \`is_production_source_path\` inside \`rules_for_path\` — mocks in tests legitimately use \`as any\` and shouldn't trip those. Existing test \`test_quality_check_detects_production_type_escape_but_allows_test_any\` (line 350) pins this distinction.

## Test plan

- [x] No behavior change. All 36 gate tests pass.
- [x] Adversarial fixture \`escape_in_test_file_should_not_fire\` fires under both the pre- and post-comment behavior (it's a defect-documenting fixture; the calibration repo treats it as a TN-or-acknowledged-FP based on this PR's resolution).

## What this prevents

Without the comment, a future maintainer reading the calibration's parity analysis (which originally called this an "inconsistency") could change \`scan_quality_escapes\` to use \`is_production_source_path\` and silently weaken detection for vestigial test-file suppressions. The 12-line comment block encodes the rationale + cites the supporting evidence so the next reader has the full context co-located with the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/future3ooo/lean-code-gate-v3/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code documentation for quality scanning logic clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->