### PR TITLE
gate: emit raw detector telemetry for calibration sweeps

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1140,6 +1140,15 @@ def multiline_added_hits(added_by_file: dict[str, list[tuple[int, str]]]) -> lis
 
 
 def duplicate_added_blocks(ctx: GateContext) -> list[dict[str, object]]:
+    return _duplicate_added_blocks_at_count(ctx, _active_min_duplicate_count)
+
+
+def duplicate_added_blocks_all(ctx: GateContext) -> list[dict[str, object]]:
+    """All raw duplicate windows (count>=2), no threshold filter. For telemetry."""
+    return _duplicate_added_blocks_at_count(ctx, 2)
+
+
+def _duplicate_added_blocks_at_count(ctx: GateContext, min_count: int) -> list[dict[str, object]]:
     windows: dict[str, dict[str, object]] = {}
     added_by_file = ctx.added_lines_with_untracked(production_only=True)
     for rel_path, lines in added_by_file.items():
@@ -1159,7 +1168,7 @@ def duplicate_added_blocks(ctx: GateContext) -> list[dict[str, object]]:
         [
             {"count": item["count"], "files": sorted(item["files"]), "sample": item["sample"]}
             for item in windows.values()
-            if int(item["count"]) >= _active_min_duplicate_count and isinstance(item["files"], set)
+            if int(item["count"]) >= min_count and isinstance(item["files"], set)
         ]
     )
 
@@ -1560,6 +1569,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     conflict_files, temp_files = changed_file_failures(repo, changed_files)
     quality_escapes = scan_quality_escapes(ctx)
     duplicates = duplicate_added_blocks(ctx)
+    duplicates_all = duplicate_added_blocks_all(ctx)
     bloat_errors, bloat_warnings, bloat_details = evaluate_bloat(ctx, active_policy)
     reuse_findings = detect_reuse_issues(ctx, active_policy)
     reuse_errors = [finding for finding in reuse_findings if finding.severity == "error"]
@@ -1595,6 +1605,8 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
         "warnings": warnings,
         "bloat": bloat_details,
         "reuseFindings": [finding.as_dict() for finding in reuse_findings],
+        "qualityEscapeLocations": list(quality_escapes),
+        "duplicateBlockCandidates": [{"count": int(d["count"]), "files": list(d["files"])} for d in duplicates_all],
     }
 
 


### PR DESCRIPTION
## Summary

- Adds two JSON output keys to \`run_quality_gate\`'s \`check\` output:
  - \`qualityEscapeLocations\`: full list (was: only first 10 in \`checks[].sample\`)
  - \`duplicateBlockCandidates\`: pre-threshold dup groups with per-group counts
- Both additive-compatible (consumers ignore unknown keys). Existing callers of \`duplicate_added_blocks(ctx)\` get the same threshold-gated result; the new \`duplicate_added_blocks_all(ctx)\` is a parallel helper for telemetry.
- Refactor: extract \`_duplicate_added_blocks_at_count(ctx, min_count)\` as the shared implementation; \`duplicate_added_blocks\` and the new \`duplicate_added_blocks_all\` both call it. Avoids duplicating the windowing loop.

## Why

The [lean-code-gate-calibration](https://github.com/future3OOO/lean-code-gate-calibration) repo's parity sweep (A19, see \`analysis/PARITY_ANALYSIS.md\`) needs raw per-group counts to vary \`reuse_min_duplicate_count\` without re-running the gate against 132 PRs. With these keys, threshold sweeps re-aggregate from existing JSONs in seconds instead of requiring a 30-min gate re-run per sweep value.

Same rationale for \`qualityEscapeLocations\`: full list lets the calibration analyzer count escape locations exactly instead of parsing the truncated \`sample[:10]\` from \`checks[]\`.

## Test plan

- [x] All 36 gate tests pass.
- [x] Re-ran calibration's 132-PR set against the patched gate; new keys populate correctly. Per-PR counts match the existing \`findingCounts.duplicateBlockGroups\` after applying the threshold filter.
- [x] No change to \`errors[]\`/\`warnings[]\` shape; gate fire-state is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/future3ooo/lean-code-gate-v3/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced duplicate block detection now reports comprehensive telemetry data for all duplicate code blocks identified in the codebase
  * Added new output fields for quality escape location analysis and duplicate block candidate tracking, including occurrence counts and associated file locations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->