### PR TITLE
gate: support Codex global installs with nested repo roots

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -14,8 +14,9 @@ import hashlib
 import json
 import os
 import re
-import subprocess
 import signal
+import shlex
+import subprocess
 import sys
 import time
 from dataclasses import dataclass
@@ -515,12 +516,16 @@ def sh(cmd: list[str], cwd: Path, timeout: int = 15) -> subprocess.CompletedProc
 def repo_root(cwd: str | None = None) -> Path:
     configured = os.environ.get("LEAN_CODE_GATE_REPO_ROOT")
     start = Path(configured or cwd or os.getcwd()).expanduser()
+    if configured and not start.exists():
+        raise SystemExit(f"LEAN_CODE_GATE_REPO_ROOT does not exist: {start}")
     if not configured and not start.exists():
         start = Path(os.getcwd())
     start = start.resolve()
     result = sh(["git", "rev-parse", "--show-toplevel"], start)
     if result.returncode == 0 and result.stdout.strip():
         return Path(result.stdout.strip()).resolve()
+    if configured:
+        raise SystemExit(f"LEAN_CODE_GATE_REPO_ROOT is not a git repository: {start}")
     return start
 
 
@@ -640,7 +645,7 @@ def deny(event: str, reason: str) -> None:
 
 def command_hint() -> str:
     script = os.environ.get("LEAN_CODE_GATE_SCRIPT_PATH") or ".agent/lean/lean_code_gate.py"
-    return f"PYTHONDONTWRITEBYTECODE=1 python3 -B -S {json.dumps(script)}"
+    return f"PYTHONDONTWRITEBYTECODE=1 python3 -B -S {shlex.quote(script)}"
 
 
 def context(event: str) -> None:

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -513,8 +513,9 @@ def sh(cmd: list[str], cwd: Path, timeout: int = 15) -> subprocess.CompletedProc
 
 
 def repo_root(cwd: str | None = None) -> Path:
-    start = Path(cwd or os.getcwd()).expanduser()
-    if not start.exists():
+    configured = os.environ.get("LEAN_CODE_GATE_REPO_ROOT")
+    start = Path(configured or cwd or os.getcwd()).expanduser()
+    if not configured and not start.exists():
         start = Path(os.getcwd())
     start = start.resolve()
     result = sh(["git", "rev-parse", "--show-toplevel"], start)
@@ -637,10 +638,15 @@ def deny(event: str, reason: str) -> None:
         emit({"decision": "block", "reason": reason})
 
 
+def command_hint() -> str:
+    script = os.environ.get("LEAN_CODE_GATE_SCRIPT_PATH") or ".agent/lean/lean_code_gate.py"
+    return f"PYTHONDONTWRITEBYTECODE=1 python3 -B -S {json.dumps(script)}"
+
+
 def context(event: str) -> None:
     message = (
         "Lean Code Gate v3 active. Inspect first, then declare the smallest Lean Change Contract before mutating files. "
-        "Micro-fix form: `PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare "
+        f"Micro-fix form: `{command_hint()} declare "
         "--minimal-preflight --intent \"...\" --scope \"file1,file2\" --task-type bugfix --verify \"pytest path/to/test.py\"`. "
         "Full production form adds --affected-surface, --authoritative-contract, --invariant, --reuse-path or --no-reuse-reason, "
         "--proof-plan, and --risk-check. Stop runs the quality gate: no fake-green suppressions, duplicate blocks, "
@@ -1749,7 +1755,7 @@ def minimal_preflight_errors(current_contract: dict[str, object], active_policy:
 def contract_errors(current_contract: dict[str, object], active_policy: dict[str, object]) -> list[str]:
     errors: list[str] = []
     if not current_contract:
-        return ["No active Lean Change Contract. Run `PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare ...` before editing."]
+        return [f"No active Lean Change Contract. Run `{command_hint()} declare ...` before editing."]
     if not meaningful(current_contract.get("intent")):
         errors.append("Missing or placeholder intent.")
     scope = current_contract.get("scope") or []

--- a/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
@@ -9,6 +9,8 @@ Use this skill for every task that may modify code, tests, build files, config, 
 
 The goal is the smallest correct production diff. The gate script is authoritative; the prose is just here because apparently agents still need a bedtime story before not ruining a repository.
 
+For global installs, use the gate script path shown by the hook reminder. The default repo-local path is `.agent/lean/lean_code_gate.py`. If Codex starts from a controller folder outside the target repo, the hook environment should set `LEAN_CODE_GATE_REPO_ROOT` to that repo.
+
 ## Required order
 
 1. Inspect before editing.

--- a/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
@@ -9,7 +9,7 @@ Use this skill for every task that may modify code, tests, build files, config, 
 
 The goal is the smallest correct production diff. The gate script is authoritative; the prose is just here because apparently agents still need a bedtime story before not ruining a repository.
 
-For global installs, use the gate script path shown by the hook reminder. The default repo-local path is `.agent/lean/lean_code_gate.py`. If Codex starts from a controller folder outside the target repo, the hook environment should set `LEAN_CODE_GATE_REPO_ROOT` to that repo.
+For global installs, set `LEAN_CODE_GATE_SCRIPT_PATH` to the gate script path shown by the hook reminder; the default repo-local path is `.agent/lean/lean_code_gate.py`. If Codex starts from a controller folder outside the target repo, the hook environment should set `LEAN_CODE_GATE_REPO_ROOT` to that repo.
 
 ## Required order
 

--- a/lean-code-gate-v3/METHODOLOGY.md
+++ b/lean-code-gate-v3/METHODOLOGY.md
@@ -97,6 +97,14 @@ Recommended rollout:
 5. Tune policy only for measured false positives.
 6. Add the `check` command to CI or pre-commit for bypass resistance.
 
+### Codex global script and target root
+
+The default Codex config assumes the gate script is installed in the target repo at `.agent/lean/lean_code_gate.py`.
+
+If Codex hooks call a shared/global copy instead, set `LEAN_CODE_GATE_SCRIPT_PATH` to that script path in the hook environment. Hook reminders and blocked-mutation messages will then show the configured path instead of the repo-local default.
+
+If Codex starts from a controller folder while the target repo is nested, set `LEAN_CODE_GATE_REPO_ROOT` to the target repo path. Policy, state, diff checks, and verification status then stay anchored to that repo. Repo-local `.agent/lean/policy.json` remains optional for per-project policy overrides.
+
 ## Limits
 
 The gate is deterministic, not omniscient. It does not prove semantic correctness or global design optimality. It prevents common failure modes that correlate with bloated agent diffs: wide scope, hidden writes, duplicate code, fake green, unverified edits, and unchecked growth. That is not magic, which is rude, but it is enforceable.

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -13,7 +13,12 @@ ROOT = Path(__file__).resolve().parents[1]
 GATE = ROOT / ".agent" / "lean" / "lean_code_gate.py"
 
 
-def run_gate(repo: Path, *args: str, payload: dict[str, object] | None = None) -> subprocess.CompletedProcess[str]:
+def run_gate(
+    repo: Path,
+    *args: str,
+    payload: dict[str, object] | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["python3", "-B", "-S", str(GATE), *args],
         cwd=repo,
@@ -22,6 +27,7 @@ def run_gate(repo: Path, *args: str, payload: dict[str, object] | None = None) -
         capture_output=True,
         check=False,
         timeout=20,
+        env={**os.environ, **(env or {})},
     )
 
 
@@ -156,6 +162,62 @@ def test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight() -> No
         result = run_gate(repo, "declare", "--intent", "edit app", "--scope", "src/app.py", "--verify", "pytest tests/test_app.py")
         assert result.returncode == 2
         assert "explicit --task-type" in result.stderr
+
+
+def test_global_script_path_env_updates_hook_guidance() -> None:
+    with repo_fixture() as repo:
+        script_path = "custom/gate script.py"
+        result = run_gate(
+            repo,
+            "session-start",
+            payload={"cwd": str(repo), "hook_event_name": "SessionStart"},
+            env={"LEAN_CODE_GATE_SCRIPT_PATH": script_path},
+        )
+        data = json.loads(result.stdout)
+        assert script_path in data["hookSpecificOutput"]["additionalContext"]
+
+        result = run_gate(
+            repo,
+            "pretool",
+            payload={
+                "cwd": str(repo),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "apply_patch",
+                "tool_input": {"command": "*** Begin Patch\n*** Add File: src/new.py\n+value = 1\n*** End Patch"},
+            },
+            env={"LEAN_CODE_GATE_SCRIPT_PATH": script_path},
+        )
+        data = json.loads(result.stdout)
+        assert script_path in data["reason"]
+
+
+def test_repo_root_env_keeps_state_in_target_repo_from_controller_cwd() -> None:
+    with repo_fixture() as repo:
+        controller = repo.parent
+        result = run_gate(
+            controller,
+            "declare",
+            "--minimal-preflight",
+            "--intent",
+            "fix small add bug",
+            "--scope",
+            "src/app.py,tests/test_app.py",
+            "--task-type",
+            "bugfix",
+            "--verify",
+            "pytest tests/test_app.py",
+            env={"LEAN_CODE_GATE_REPO_ROOT": str(repo)},
+        )
+        assert result.returncode == 0, result.stderr
+        assert json.loads((repo / ".agent" / "lean" / "state" / "contract.json").read_text(encoding="utf-8"))["intent"] == "fix small add bug"
+        assert not (controller / ".agent" / "lean" / "state" / "contract.json").exists()
+
+        result = run_gate(
+            controller,
+            "status",
+            env={"LEAN_CODE_GATE_REPO_ROOT": str(repo)},
+        )
+        assert json.loads(result.stdout)["contract"]["intent"] == "fix small add bug"
 
 
 def test_minimal_preflight_rejects_wide_budget_and_escape_hatches() -> None:
@@ -869,6 +931,8 @@ TESTS = [
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,
+    test_global_script_path_env_updates_hook_guidance,
+    test_repo_root_env_keeps_state_in_target_repo_from_controller_cwd,
     test_minimal_preflight_rejects_wide_budget_and_escape_hatches,
     test_edit_rewrite_counts_as_changed_lines,
     test_pretool_blocks_out_of_scope_patch,

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -27,7 +28,7 @@ def run_gate(
         capture_output=True,
         check=False,
         timeout=20,
-        env={**os.environ, **(env or {})},
+        env={**os.environ, "LEAN_CODE_GATE_REPO_ROOT": "", "LEAN_CODE_GATE_SCRIPT_PATH": "", **(env or {})},
     )
 
 
@@ -166,7 +167,8 @@ def test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight() -> No
 
 def test_global_script_path_env_updates_hook_guidance() -> None:
     with repo_fixture() as repo:
-        script_path = "custom/gate script.py"
+        script_path = "custom/$gate dir/`script`.py"
+        quoted_script_path = shlex.quote(script_path)
         result = run_gate(
             repo,
             "session-start",
@@ -174,7 +176,7 @@ def test_global_script_path_env_updates_hook_guidance() -> None:
             env={"LEAN_CODE_GATE_SCRIPT_PATH": script_path},
         )
         data = json.loads(result.stdout)
-        assert script_path in data["hookSpecificOutput"]["additionalContext"]
+        assert quoted_script_path in data["hookSpecificOutput"]["additionalContext"]
 
         result = run_gate(
             repo,
@@ -188,36 +190,62 @@ def test_global_script_path_env_updates_hook_guidance() -> None:
             env={"LEAN_CODE_GATE_SCRIPT_PATH": script_path},
         )
         data = json.loads(result.stdout)
-        assert script_path in data["reason"]
+        assert quoted_script_path in data["reason"]
 
 
 def test_repo_root_env_keeps_state_in_target_repo_from_controller_cwd() -> None:
     with repo_fixture() as repo:
-        controller = repo.parent
-        result = run_gate(
-            controller,
-            "declare",
-            "--minimal-preflight",
-            "--intent",
-            "fix small add bug",
-            "--scope",
-            "src/app.py,tests/test_app.py",
-            "--task-type",
-            "bugfix",
-            "--verify",
-            "pytest tests/test_app.py",
-            env={"LEAN_CODE_GATE_REPO_ROOT": str(repo)},
-        )
-        assert result.returncode == 0, result.stderr
-        assert json.loads((repo / ".agent" / "lean" / "state" / "contract.json").read_text(encoding="utf-8"))["intent"] == "fix small add bug"
-        assert not (controller / ".agent" / "lean" / "state" / "contract.json").exists()
+        with tempfile.TemporaryDirectory(prefix="gate-controller-", dir=str(repo.parent)) as ctrl:
+            controller = Path(ctrl)
+            result = run_gate(
+                controller,
+                "declare",
+                "--minimal-preflight",
+                "--intent",
+                "fix small add bug",
+                "--scope",
+                "src/app.py,tests/test_app.py",
+                "--task-type",
+                "bugfix",
+                "--verify",
+                "pytest tests/test_app.py",
+                env={"LEAN_CODE_GATE_REPO_ROOT": str(repo)},
+            )
+            assert result.returncode == 0, result.stderr
+            assert json.loads((repo / ".agent" / "lean" / "state" / "contract.json").read_text(encoding="utf-8"))["intent"] == "fix small add bug"
+            assert not (controller / ".agent" / "lean" / "state" / "contract.json").exists()
 
+            result = run_gate(
+                controller,
+                "status",
+                env={"LEAN_CODE_GATE_REPO_ROOT": str(repo)},
+            )
+            assert json.loads(result.stdout)["contract"]["intent"] == "fix small add bug"
+
+
+def test_repo_root_env_rejects_missing_target_repo() -> None:
+    with repo_fixture() as repo:
+        missing = repo.parent / "missing-target"
         result = run_gate(
-            controller,
+            repo,
             "status",
-            env={"LEAN_CODE_GATE_REPO_ROOT": str(repo)},
+            env={"LEAN_CODE_GATE_REPO_ROOT": str(missing)},
         )
-        assert json.loads(result.stdout)["contract"]["intent"] == "fix small add bug"
+        assert result.returncode != 0
+        assert "LEAN_CODE_GATE_REPO_ROOT does not exist" in result.stderr
+        assert str(missing) in result.stderr
+
+
+def test_repo_root_env_rejects_non_git_target_repo() -> None:
+    with repo_fixture() as repo:
+        with tempfile.TemporaryDirectory(prefix="not-a-repo-", dir=str(repo.parent)) as other:
+            result = run_gate(
+                repo,
+                "status",
+                env={"LEAN_CODE_GATE_REPO_ROOT": other},
+            )
+            assert result.returncode != 0
+            assert "LEAN_CODE_GATE_REPO_ROOT is not a git repository" in result.stderr
 
 
 def test_minimal_preflight_rejects_wide_budget_and_escape_hatches() -> None:
@@ -933,6 +961,8 @@ TESTS = [
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,
     test_global_script_path_env_updates_hook_guidance,
     test_repo_root_env_keeps_state_in_target_repo_from_controller_cwd,
+    test_repo_root_env_rejects_missing_target_repo,
+    test_repo_root_env_rejects_non_git_target_repo,
     test_minimal_preflight_rejects_wide_budget_and_escape_hatches,
     test_edit_rewrite_counts_as_changed_lines,
     test_pretool_blocks_out_of_scope_patch,


### PR DESCRIPTION
## Summary

- Add `LEAN_CODE_GATE_REPO_ROOT` so Codex controller folders can target a nested repo cleanly.
- Keep repo-local installs as the default when the env var is unset.
- Keep `LEAN_CODE_GATE_SCRIPT_PATH` only for hook guidance/block messages when the gate script is installed globally.
- Document the global script path and target-root behavior without hard-coding OS-specific install paths.

## Root Cause

Codex can be launched from a controller folder while the actual source repo lives underneath it. The gate previously resolved policy, state, and diff context from the hook cwd unless the caller was already inside the target repo. That made global installs and nested repo workflows easy to misconfigure.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S lean-code-gate-v3/tests/test_lean_code_gate.py` -> 38 tests passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S lean-code-gate-v3/.agent/lean/lean_code_gate.py check --repo . --json` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add support for configuring a custom gate script path and repository root via environment variables
  * Dynamic, quoted command hints shown in user-facing guidance

* **Bug Fixes / Behavior**
  * If a configured repository root is invalid or not a repo, the tool now exits with a clear error (previous fallback preserved when not configured)

* **Documentation**
  * Expanded guidance for global/shared and controller-based setups

* **Tests**
  * Added tests for env-driven behavior, success and failure paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->