### PR TITLE
P0: add advisory finding surface

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -373,6 +373,8 @@ GENERIC_MATCH_TOKENS = {
     "wait",
     "with",
 }
+ADVISORY_GROUP_NAMES = ("securityAssumptionFindings", "slopShapeFindings", "verificationShapeFindings")
+ADVISORY_BUCKET_NAMES = ("added", "resolved", "worsened", "improved")
 RISKY_BLOCK_RULE = re.compile(
     r"\b(?:for|while|map|filter|reduce|retry|fetch|read|write|parse|normalize|validate|format|resolve|dedupe|deduplicate)\b",
     re.I,
@@ -1730,6 +1732,11 @@ def apply_active_policy(active_policy: dict[str, object]) -> None:
     _active_min_duplicate_count = max(2, int(active_policy.get("reuse_min_duplicate_count") or 2))
 
 
+
+def empty_advisory_groups() -> dict[str, dict[str, list[dict[str, object]]]]:
+    return {name: {bucket: [] for bucket in ADVISORY_BUCKET_NAMES} for name in ADVISORY_GROUP_NAMES}
+
+
 def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -> dict[str, object]:
     active_policy = policy(repo)
     apply_active_policy(active_policy)
@@ -1778,6 +1785,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
         "reuseFindings": [finding.as_dict() for finding in reuse_findings],
         "qualityEscapeLocations": list(quality_escapes),
         "duplicateBlockCandidates": [{"count": int(d["count"]), "files": list(d["files"])} for d in duplicates_all],
+        **empty_advisory_groups(),
     }
 
 

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -133,6 +133,27 @@ def snapshot_paths(repo: Path) -> set[str]:
     return {str(path.relative_to(repo)) for path in repo.rglob("*") if ".git" not in path.relative_to(repo).parts}
 
 
+
+def test_p0_advisory_groups_are_empty_and_compatible() -> None:
+    with repo_fixture() as repo:
+        code, data = check_json(repo)
+        assert code == 0
+        for name in ("securityAssumptionFindings", "slopShapeFindings", "verificationShapeFindings"):
+            assert data[name] == {"added": [], "resolved": [], "worsened": [], "improved": []}
+        assert data["ok"] is True
+        assert data["warnings"] == []
+        assert all(item["passed"] for item in data["checks"])
+        assert all(item["passed"] for item in data["hardRules"].values())
+
+        text_result = run_gate(repo, "check", "--repo", str(repo))
+        assert text_result.returncode == 0
+        assert "Advisory findings" not in text_result.stdout
+
+        promoted = run_gate(repo, "check", "--repo", str(repo), "--fail-on-warnings", "--json")
+        promoted_data = json.loads(promoted.stdout)
+        assert promoted.returncode == 0
+        assert promoted_data["errors"] == []
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1186,6 +1207,7 @@ def test_gate_check_creates_no_repo_artifacts() -> None:
 
 
 TESTS = [
+    test_p0_advisory_groups_are_empty_and_compatible,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,


### PR DESCRIPTION
# PR0_P0_advisory_surface

Problem:
P1-P5 would otherwise invent separate output plumbing and accidentally affect blocker paths.

Named failure mode:
Inconsistent advisory output surface and accidental promotion path.

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, both lean-code skill docs, and supplied Lean Gate Improvement Plan V1.3. calibration/HANDOVER.md and calibration/analysis/COHORT_TABLE.md were named by the plan but absent from the supplied archive, so no current-corpus rerun claim is made.

Exact scope:
run_quality_gate output shape and compatibility tests only; no detectors, no formatter framework, no declare/status/final_errors coupling.

Existing surfaces touched:
Adds empty additive advisory JSON groups in run_quality_gate and pins compatibility in tests.

Files changed:
- .agent/lean/lean_code_gate.py
- tests/test_lean_code_gate.py

Net lean_code_gate.py lines added:
8 net (8 added / 0 deleted).

Helpers reused:
Existing run_quality_gate result assembly and existing test helper surfaces.

Helpers added:
ADVISORY_GROUP_NAMES, ADVISORY_BUCKET_NAMES, empty_advisory_groups.

Why existing helpers were insufficient:
No existing shared advisory container existed. Inline dicts were considered, but one small helper reduces repeated shape mistakes once P1-P5 populate the groups.

Deletion/consolidation attempted:
No detector or text formatter code added. P0 stayed at the smallest shared JSON surface needed by later PRs.

Chosen path:
Empty additive containers only, populated with four stable buckets per family.

Rejected simpler paths:
Dataclass, status/declare/final_errors integration, legacy warnings, hard blockers, text sections for empty groups, and new CLI fields.

Compatibility impact:
CLI, hook commands, python3 -B -S execution, zero dependencies, copied/global install, repo-local install, and Claude/Codex symmetry are preserved. Advisory findings do not affect ok, legacy warnings, checks, hardRules, empty text output, or fail_on_quality_warnings.

Verification:
See VERIFY.log. Focused compatibility test and dogfood check were run at this PR state.

Calibration rule:
Warning/advisory-only PR. Focused fixtures and dogfood are sufficient for landing. Hard-failure promotion requires fresh current-corpus per-rule attribution and FP below duplicate-block baseline.

Rollback path:
Revert this PR before release. After release, advisory field names should remain for JSON compatibility unless a migration note is provided.


---
Stack position: `v13/p0-advisory-surface` targeting `main`. Source stack: `lean_gate_v13_pr_stack (2).zip`. Base commit: `0bb9ba4197bc2006a895c88190480c17738dd413`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advisory telemetry scaffolding to quality gate output, ensuring advisory finding groups are always included in results.

* **Tests**
  * Added regression test validating the JSON contract for advisory findings and quality gate output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->