### PR TITLE
P1: add sensitive input advisories

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -307,6 +307,20 @@ EMPTY_CATCH_RULES = [
     re.compile(r"except\s+Exception\s*:\s*\n\s*pass\b", re.S),
     re.compile(r"except\s*:\s*\n\s*pass\b", re.S),
 ]
+SENSITIVE_SOURCE_RULES = [
+    (re.compile(r"\b(?:os\.getenv|os\.environ|process\.env|Deno\.env\.get|std::env::var|os\.Getenv|getenv)\b"), "environment-read"),
+    (re.compile(r"\bgit\s+(?:remote\s+get-url|config\s+--get\s+remote\.)"), "git-remote-url-read"),
+    (re.compile(r"(?:^|[/\\])(?:\.netrc|\.ssh|\.aws)(?:[/\\]|$)|\b(?:id_rsa|id_ed25519|known_hosts)\b"), "credential-file-read"),
+    (re.compile(r"\b(?:keyring\.|keytar\.|SecretStorage|security\s+find-generic-password)"), "keyring-read"),
+    (re.compile(r"\b(?:Authorization|Cookie|Set-Cookie)\b"), "auth-header-read"),
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private-key-material"),
+]
+SENSITIVE_SINK_RULES = [
+    (re.compile(r"\b(?:console\.(?:log|error|warn)|print|fmt\.Print(?:f|ln)?|println!|eprintln!|logger?\.|log\.)\s*\("), "log-or-console"),
+    (re.compile(r"\b(?:JSON\.stringify|json\.dumps|pickle\.dump|yaml\.dump|serialize|snapshot|telemetry|emit)\b"), "serialization-or-telemetry"),
+    (re.compile(r"\b(?:write_text|write_bytes|writeFile|appendFile|open\s*\([^)]*['\"]w|cache|state)\b"), "persistence"),
+    (re.compile(r"\b(?:status|error|message|response)\s*[=:]"), "status-or-error-text"),
+]
 GENERIC_SYMBOLS = {
     "app",
     "config",
@@ -1247,6 +1261,46 @@ def line_hits(path: str, lines: list[tuple[int, str]], rules: list[re.Pattern[st
     return hits
 
 
+
+def advisory_finding(rule: str, family: str, path: str, line: int, severity: str, message: str, evidence: str) -> dict[str, object]:
+    return {
+        "rule": rule,
+        "family": family,
+        "path": path,
+        "line": line,
+        "severity": severity,
+        "message": message,
+        "evidence": evidence,
+    }
+
+
+def first_rule_match(text: str, rules: list[tuple[re.Pattern[str], str]]) -> str:
+    return next((label for pattern, label in rules if pattern.search(text)), "")
+
+
+def scan_sensitive_input(ctx: GateContext) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items():
+        if is_production_source_path(rel_path):
+            findings.extend(scan_sensitive_input_lines(rel_path, lines))
+    return findings
+
+
+def scan_sensitive_input_lines(path: str, lines: list[tuple[int, str]]) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    sinks = [(line_no, first_rule_match(text, SENSITIVE_SINK_RULES)) for line_no, text in lines]
+    for line_no, text in lines:
+        source = first_rule_match(text, SENSITIVE_SOURCE_RULES)
+        if not source:
+            continue
+        sink = next((label for sink_line, label in sinks if label and abs(sink_line - line_no) <= 8), "")
+        severity = "high" if sink else "warning"
+        evidence = f"source={source}" + (f"; sink={sink}" if sink else "")
+        message = "added code reads sensitive input" + (" and exposes or persists it nearby" if sink else "; keep it out of logs, cache, and telemetry")
+        findings.append(advisory_finding("sensitive-input", "security", path, line_no, severity, message, evidence))
+    return findings
+
+
 def multiline_hits(path: str, text: str) -> list[str]:
     return [f"{path}:{text[: match.start()].count(chr(10)) + 1}" for rule in EMPTY_CATCH_RULES for match in rule.finditer(text)]
 
@@ -1752,6 +1806,8 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     reuse_findings = detect_reuse_issues(ctx, active_policy)
     reuse_errors = [finding for finding in reuse_findings if finding.severity == "error"]
     reuse_warnings = [finding for finding in reuse_findings if finding.severity == "warning"]
+    advisory_groups = empty_advisory_groups()
+    advisory_groups["securityAssumptionFindings"]["added"].extend(scan_sensitive_input(ctx))
 
     if conflict_files:
         errors.append(f"merge conflict markers found in {len(conflict_files)} file(s)")
@@ -1785,7 +1841,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
         "reuseFindings": [finding.as_dict() for finding in reuse_findings],
         "qualityEscapeLocations": list(quality_escapes),
         "duplicateBlockCandidates": [{"count": int(d["count"]), "files": list(d["files"])} for d in duplicates_all],
-        **empty_advisory_groups(),
+        **advisory_groups,
     }
 
 
@@ -1835,6 +1891,29 @@ def hard_rules(checks: list[dict[str, object]]) -> dict[str, dict[str, object]]:
     }
 
 
+def advisory_findings(result: dict[str, object]) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for group_name in ADVISORY_GROUP_NAMES:
+        group = result.get(group_name)
+        if not isinstance(group, dict):
+            continue
+        for bucket in ADVISORY_BUCKET_NAMES:
+            values = group.get(bucket)
+            if isinstance(values, list):
+                findings.extend(item for item in values if isinstance(item, dict))
+    return findings
+
+
+def format_advisory_sample(finding: dict[str, object]) -> str:
+    path = str(finding.get("path") or "unknown")
+    line = int(finding.get("line") or 0)
+    severity = str(finding.get("severity") or "warning")
+    rule = str(finding.get("rule") or "advisory")
+    message = str(finding.get("message") or "advisory finding")
+    location = f"{path}:{line}" if line else path
+    return f"- {severity} {rule} at {location}: {message}"
+
+
 def format_quality_text(result: dict[str, object]) -> str:
     lines = [
         "Lean Code Quality Gate",
@@ -1852,6 +1931,13 @@ def format_quality_text(result: dict[str, object]) -> str:
     lines.append("")
     lines.append("Warnings:")
     lines.extend([f"- {warning}" for warning in result["warnings"]] if result["warnings"] else ["- none"])
+    findings = advisory_findings(result)
+    if findings:
+        lines.append("")
+        lines.append("Advisory findings:")
+        lines.extend(format_advisory_sample(finding) for finding in findings[:8])
+        if len(findings) > 8:
+            lines.append(f"- ... {len(findings) - 8} more advisory finding(s)")
     return "\n".join(lines)
 
 

--- a/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
@@ -111,6 +111,7 @@ Escape hatches need evidence:
 - No new package if standard library or an existing package solves the problem cleanly.
 - No second package manager or second lockfile.
 - No broad error handling for impossible scenarios.
+- Treat production-code reads from environment, credential files, keyrings, auth/cookie headers, private keys, or git remote URLs as sensitive input; name the risk in `--risk-check` and never log, serialize, cache, snapshot, or emit the values.
 - No fake-green patterns: `|| true`, blanket suppressions, broad catch/pass, empty catch, `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `# type: ignore`, `# noqa`.
 - No `TODO`, `FIXME`, `HACK`, placeholders, dummy adapters, temporary bypasses, or unfinished stubs in changed source.
 - Delete only orphans created by your own change.

--- a/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
@@ -111,6 +111,7 @@ Escape hatches need evidence:
 - No new package if standard library or an existing package solves the problem cleanly.
 - No second package manager or second lockfile.
 - No broad error handling for impossible scenarios.
+- Treat production-code reads from environment, credential files, keyrings, auth/cookie headers, private keys, or git remote URLs as sensitive input; name the risk in `--risk-check` and never log, serialize, cache, snapshot, or emit the values.
 - No fake-green patterns: `|| true`, blanket suppressions, broad catch/pass, empty catch, `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `# type: ignore`, `# noqa`.
 - No `TODO`, `FIXME`, `HACK`, placeholders, dummy adapters, temporary bypasses, or unfinished stubs in changed source.
 - Delete only orphans created by your own change.

--- a/lean-code-gate-v3/METHODOLOGY.md
+++ b/lean-code-gate-v3/METHODOLOGY.md
@@ -84,6 +84,8 @@ The final quality gate inspects the changed source scope and fails on:
 - high-confidence helper or loop reimplementation
 - risk-calibrated bloat
 
+The advisory surface also reports sensitive-input reads when changed production code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value.
+
 Warnings are emitted for moderate bloat and weaker reuse signals. Projects can promote warnings to failures in `.agent/lean/policy.json`.
 
 ## Operating guidance

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -154,6 +154,68 @@ def test_p0_advisory_groups_are_empty_and_compatible() -> None:
         assert promoted.returncode == 0
         assert promoted_data["errors"] == []
 
+
+def _advisory_added(data: dict[str, object], group: str) -> list[dict[str, object]]:
+    return list(data[group]["added"])
+
+
+def test_sensitive_input_source_only_is_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "secrets.py").write_text("import os\nTOKEN = os.environ['API_KEY']\n", encoding="utf-8")
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "warning"
+        assert findings[0]["evidence"] == "source=environment-read"
+        assert data["warnings"] == []
+        assert all(item["passed"] for item in data["checks"])
+
+
+def test_sensitive_input_source_and_sink_is_stronger_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "secrets.py").write_text(
+            "import os\nTOKEN = os.getenv('API_KEY')\nprint(TOKEN)\n", encoding="utf-8"
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+        assert "API_KEY" not in findings[0]["evidence"]
+        assert "API_KEY" not in findings[0]["message"]
+
+
+def test_sensitive_input_unchanged_broad_names_and_test_fixtures_do_not_hit() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "seed.py").write_text("import os\nTOKEN = os.environ['API_KEY']\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed sensitive read")
+        (repo / "src" / "seed.py").write_text(
+            "import os\nTOKEN = os.environ['API_KEY']\nVALUE = 1\n", encoding="utf-8"
+        )
+        (repo / "src" / "names.py").write_text("secret_payload = load_user_setting()\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "securityAssumptionFindings") == []
+        (repo / "tests" / "test_secret_fixture.py").write_text(
+            "import os\nTOKEN = os.environ['API_KEY']\nopen('out.txt', 'w').write(TOKEN)\n", encoding="utf-8"
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "securityAssumptionFindings") == []
+
+
+def test_sensitive_input_text_output_is_advisory_only() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "secrets.py").write_text("import os\nTOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
+        result = run_gate(repo, "check", "--repo", str(repo))
+        assert result.returncode == 0
+        assert "Advisory findings" in result.stdout
+        assert "Warnings:\n- none" in result.stdout
+
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1208,6 +1270,10 @@ def test_gate_check_creates_no_repo_artifacts() -> None:
 
 TESTS = [
     test_p0_advisory_groups_are_empty_and_compatible,
+    test_sensitive_input_source_only_is_advisory,
+    test_sensitive_input_source_and_sink_is_stronger_advisory,
+    test_sensitive_input_unchanged_broad_names_and_test_fixtures_do_not_hit,
+    test_sensitive_input_text_output_is_advisory_only,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,


### PR DESCRIPTION
# PR1_sensitive_input

Problem:
Added production code can read credential-bearing inputs, with higher risk when nearby touched code emits or persists them.

Named failure mode:
Sensitive source read; stronger advisory when a source and sink are both visible in the touched production source region.

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, both lean-code skill docs, and supplied Lean Gate Improvement Plan V1.3. calibration/HANDOVER.md and calibration/analysis/COHORT_TABLE.md were named by the plan but absent from the supplied archive, so no current-corpus rerun claim is made.

Exact scope:
Production source paths only; test fixtures are excluded because fake secrets and fake sinks are intentionally common there.

Existing surfaces touched:
Populates P0 securityAssumptionFindings; uses touched added production lines and existing path/language helpers; updates risk_check guidance.

Files changed:
- .agent/lean/lean_code_gate.py
- .agents/skills/lean-code/SKILL.md
- .claude/skills/lean-code/SKILL.md
- METHODOLOGY.md
- tests/test_lean_code_gate.py

Net lean_code_gate.py lines added:
86 net (87 added / 1 deleted).

Helpers reused:
GateContext.added_lines_with_untracked(production_only=True), is_production_source_path, language/path helpers, P0 advisory containers.

Helpers added:
advisory_finding, first_rule_match, scan_sensitive_input, scan_sensitive_input_lines, advisory_findings, format_advisory_sample.

Why existing helpers were insufficient:
Existing quality-escape rules are blocker-oriented, and a broad credential-name scanner would become a noisy credential catalog.

Deletion/consolidation attempted:
Scoped to production source paths rather than excluding all tests in a global way; no credential regex catalog, no whole-repo scan, no hard blocker.

Chosen path:
Small deterministic source/sink recognizers with sanitized labels as evidence, never raw secret values.

Rejected simpler paths:
Legacy warnings, hard blockers, scanning test fixtures, raw value evidence, broad auth/session/webhook/secret payload-name matching, and AST dependencies.

Compatibility impact:
CLI, hook commands, python3 -B -S execution, zero dependencies, copied/global install, repo-local install, and Claude/Codex symmetry are preserved. Advisory findings do not affect ok, legacy warnings, checks, hardRules, empty text output, or fail_on_quality_warnings.

Verification:
See VERIFY.log. Focused tests cover source-only, source+sink, unchanged/non-hit, test-fixture non-hit, sanitized evidence, and advisory-only text behavior.

Calibration rule:
Warning/advisory-only PR. Focused fixtures and dogfood are sufficient for landing. Hard-failure promotion requires fresh current-corpus per-rule attribution and FP below duplicate-block baseline.

Rollback path:
Delete the sensitive-input helpers, run_quality_gate population call, risk_check docs, and focused tests. P0 fields remain.


---
Stack position: `v13/p1-sensitive-input` targeting `v13/p0-advisory-surface`. Source stack: `lean_gate_v13_pr_stack (2).zip`. Base commit: `0bb9ba4197bc2006a895c88190480c17738dd413`.