### PR TITLE
P3: add wrapper value advisories

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -325,6 +325,10 @@ FAILURE_DEFAULT_RE = re.compile(r'(?:\breturn\s+|=>\s*)(?:null|undefined|false|\
 FAILURE_LOG_RE = re.compile(r"\b(?:console\.(?:log|error|warn)|logger?\.(?:log|error|warn)|log\.(?:error|warn|info))\s*\(")
 FAILURE_RETHROW_RE = re.compile(r"\b(?:throw|reject|raise)\b")
 FAILURE_STRINGIFY_RE = re.compile(r"\b(?:JSON\.stringify|String)\s*\(\s*(?:e|err|error)\s*\)")
+WRAPPER_VALUE_MARKER_RE = re.compile(
+    r"\b(?:compat|deprecated|deprecation|alias|public\s+api|validate|validation|normalize|normalise|sanitize|instrument|metric|trace|log|retry|timeout|boundary|external|adapter|hook|override)\b",
+    re.I,
+)
 GENERIC_SYMBOLS = {
     "app",
     "config",
@@ -1350,6 +1354,92 @@ def scan_failure_contract_lines(path: str, lines: list[tuple[int, str]], current
     return unique_advisory_findings(findings)
 
 
+def scan_wrapper_value(ctx: GateContext) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items():
+        if is_production_source_path(rel_path):
+            findings.extend(scan_wrapper_value_lines(rel_path, lines))
+    return unique_advisory_findings(findings)
+
+
+def scan_wrapper_value_lines(path: str, lines: list[tuple[int, str]]) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    language = language_for_path(path)
+    for line_no, text in lines:
+        match_info = wrapper_forwarder(language, text)
+        if not match_info:
+            continue
+        name, target, args, call_args = match_info
+        if name in _active_framework_override_names or target.rsplit(".", 1)[-1] == name:
+            continue
+        if not same_pass_through_args(args, call_args) or WRAPPER_VALUE_MARKER_RE.search(added_line_window(lines, line_no, 3)):
+            continue
+        findings.append(
+            advisory_finding(
+                "wrapper-value",
+                "wrapper",
+                path,
+                line_no,
+                "warning",
+                "one-line forwarding function adds indirection without visible boundary value",
+                f"{name} forwards to {target} with pass-through arguments",
+            )
+        )
+    return findings
+
+
+def wrapper_forwarder(language: str, text: str) -> tuple[str, str, str, str] | None:
+    stripped = text.strip()
+    if language == "python":
+        found = re.search(r"^(?:async\s+)?def\s+(\w+)\s*\(([^)]*)\)\s*:\s*return\s+(?:await\s+)?([A-Za-z_][\w.]*)\s*\(([^)]*)\)\s*$", stripped)
+        if found:
+            return found.group(1), found.group(3), found.group(2), found.group(4)
+    elif language == "javascript":
+        found = re.search(r"^(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)\s*\{\s*return\s+(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)\s*;?\s*\}\s*$", stripped)
+        if found:
+            return found.group(1), found.group(3), found.group(2), found.group(4)
+        found = re.search(r"^(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?(.*?)\s*=>\s*(.*?)\s*;?\s*$", stripped)
+        if found:
+            name, raw_args, body = found.group(1), found.group(2).strip(), found.group(3).strip()
+            if raw_args.startswith("(") and raw_args.endswith(")"):
+                raw_args = raw_args[1:-1]
+            body_match = re.search(r"^(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)$", body)
+            if not body_match and body.startswith("{") and body.endswith("}"):
+                body_match = re.search(r"^\{\s*return\s+(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)\s*;?\s*\}$", body)
+            if body_match:
+                return name, body_match.group(1), raw_args, body_match.group(2)
+    elif language == "go":
+        found = re.search(r"^func\s+(?:\([^)]*\)\s*)?(\w+)\s*\(([^)]*)\)[^{]*\{\s*return\s+([A-Za-z_][\w.]*)\s*\(([^)]*)\)\s*\}\s*$", stripped)
+        if found:
+            return found.group(1), found.group(3), found.group(2), found.group(4)
+    return None
+
+def arg_names(raw: str) -> list[str]:
+    names: list[str] = []
+    for part in raw.split(","):
+        item = part.strip().lstrip("*").lstrip("&")
+        if not item or item.startswith("...") or item.startswith("{") or item.startswith("["):
+            continue
+        item = item.split("=", 1)[0].split(":", 1)[0].strip()
+        tokens = re.findall(r"[A-Za-z_$][\w$]*", item)
+        if tokens:
+            names.append(tokens[0])
+    return [name for name in names if name not in {"self", "this", "cls"}]
+
+
+def call_arg_names(raw: str) -> list[str]:
+    names: list[str] = []
+    for part in raw.split(","):
+        item = part.strip()
+        if re.match(r"^[A-Za-z_$][\w$]*$", item):
+            names.append(item)
+    return [name for name in names if name not in {"self", "this", "cls"}]
+
+
+def same_pass_through_args(args: str, call_args: str) -> bool:
+    return arg_names(args) == call_arg_names(call_args)
+
+
 def unique_advisory_findings(findings: list[dict[str, object]]) -> list[dict[str, object]]:
     seen: set[tuple[object, ...]] = set()
     out: list[dict[str, object]] = []
@@ -1869,6 +1959,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     advisory_groups = empty_advisory_groups()
     advisory_groups["securityAssumptionFindings"]["added"].extend(scan_sensitive_input(ctx))
     advisory_groups["slopShapeFindings"]["added"].extend(scan_failure_contract(ctx))
+    advisory_groups["slopShapeFindings"]["added"].extend(scan_wrapper_value(ctx))
 
     if conflict_files:
         errors.append(f"merge conflict markers found in {len(conflict_files)} file(s)")

--- a/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
@@ -107,7 +107,7 @@ Escape hatches need evidence:
 
 - Minimum code that solves the requested behavior.
 - Extend existing implementation before adding a parallel one.
-- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, or configuration knobs.
+- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, configuration knobs, or one-line forwarding wrappers unless they provide validation, normalization, instrumentation, retry, compatibility, deprecation, or external-boundary value.
 - No new package if standard library or an existing package solves the problem cleanly.
 - No second package manager or second lockfile.
 - No broad error handling for impossible scenarios, log-only catches, stringified unknown errors, or catch paths that return `null`, `undefined`, `false`, empty arrays, empty objects, or empty strings.

--- a/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
@@ -107,7 +107,7 @@ Escape hatches need evidence:
 
 - Minimum code that solves the requested behavior.
 - Extend existing implementation before adding a parallel one.
-- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, or configuration knobs.
+- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, configuration knobs, or one-line forwarding wrappers unless they provide validation, normalization, instrumentation, retry, compatibility, deprecation, or external-boundary value.
 - No new package if standard library or an existing package solves the problem cleanly.
 - No second package manager or second lockfile.
 - No broad error handling for impossible scenarios, log-only catches, stringified unknown errors, or catch paths that return `null`, `undefined`, `false`, empty arrays, empty objects, or empty strings.

--- a/lean-code-gate-v3/METHODOLOGY.md
+++ b/lean-code-gate-v3/METHODOLOGY.md
@@ -84,7 +84,7 @@ The final quality gate inspects the changed source scope and fails on:
 - high-confidence helper or loop reimplementation
 - risk-calibrated bloat
 
-The advisory surface also reports sensitive-input reads when changed production code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value. TypeScript and JavaScript catch/reject paths are advisory findings when they only log, stringify unknown errors, or return cheap defaults such as `null`, `undefined`, `false`, empty arrays, empty objects, or empty strings.
+The advisory surface also reports sensitive-input reads when changed production code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value. TypeScript and JavaScript catch/reject paths are advisory findings when they only log, stringify unknown errors, or return cheap defaults such as `null`, `undefined`, `false`, empty arrays, empty objects, or empty strings. New one-line forwarding wrappers are advisory findings when no nearby validation, normalization, instrumentation, retry, compatibility, deprecation, or external-boundary value is visible.
 
 Warnings are emitted for moderate bloat and weaker reuse signals. Projects can promote warnings to failures in `.agent/lean/policy.json`.
 

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -273,6 +273,35 @@ def test_failure_contract_preserving_errors_and_unchanged_catches_do_not_hit() -
         assert code == 0, data
         assert _advisory_added(data, "slopShapeFindings") == []
 
+
+def test_wrapper_value_detects_python_ts_and_go_forwarders() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "wrap.py").write_text("def get_user(user_id): return load_user(user_id)\n", encoding="utf-8")
+        (repo / "src" / "wrap.ts").write_text("export const getAccount = (id: string) => loadAccount(id);\n", encoding="utf-8")
+        (repo / "src" / "wrap.go").write_text("package main\nfunc ReadUser(id string) User { return GetUser(id) }\n", encoding="utf-8")
+        code, data = check_json(repo)
+        findings = [item for item in _advisory_added(data, "slopShapeFindings") if item["rule"] == "wrapper-value"]
+        assert code == 0, data
+        assert len(findings) == 3
+        assert {item["path"] for item in findings} == {"src/wrap.py", "src/wrap.ts", "src/wrap.go"}
+
+
+def test_wrapper_value_markers_and_framework_overrides_do_not_hit() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "compat.py").write_text(
+            "# deprecated compatibility shim for old public API\n"
+            "def old_user(user_id): return load_user(user_id)\n"
+            "# instrumentation boundary keeps metrics stable\n"
+            "def traced_user(user_id): return load_user(user_id)\n"
+            "# retry adapter for external boundary\n"
+            "def fetch_user(user_id): return load_user(user_id)\n"
+            "def render(self): return base_render(self)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert [item for item in _advisory_added(data, "slopShapeFindings") if item["rule"] == "wrapper-value"] == []
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1335,6 +1364,8 @@ TESTS = [
     test_failure_contract_multiline_log_and_default_is_advisory,
     test_failure_contract_stringified_unknown_is_advisory,
     test_failure_contract_preserving_errors_and_unchanged_catches_do_not_hit,
+    test_wrapper_value_detects_python_ts_and_go_forwarders,
+    test_wrapper_value_markers_and_framework_overrides_do_not_hit,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,


### PR DESCRIPTION
# PR3_wrapper_value

Problem:
New one-line forwarding functions can add indirection without validation, normalization, instrumentation, compatibility, retry, or boundary value.

Named failure mode:
Valueless wrapper shape in newly added production source code.

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, both lean-code skill docs, and supplied Lean Gate Improvement Plan V1.3. calibration/HANDOVER.md and calibration/analysis/COHORT_TABLE.md were named by the plan but absent from the supplied archive, so no current-corpus rerun claim is made.

Exact scope:
Added production source lines only; Python, JS/TS, and Go one-line direct forwarders; no fanout/barrel/topology scoring.

Existing surfaces touched:
Populates P0 slopShapeFindings; reuses production-only added lines, language_for_path, and framework override/value-marker concepts.

Files changed:
- .agent/lean/lean_code_gate.py
- .agents/skills/lean-code/SKILL.md
- .claude/skills/lean-code/SKILL.md
- METHODOLOGY.md
- tests/test_lean_code_gate.py

Net lean_code_gate.py lines added:
91 net (91 added / 0 deleted).

Helpers reused:
GateContext.added_lines_with_untracked(production_only=True), language_for_path, framework_override_names, path helpers, P0 advisory containers.

Helpers added:
scan_wrapper_value, wrapper_line_forwards, wrapper_has_value_marker, wrapper_args_passthrough, wrapper_call_target.

Why existing helpers were insufficient:
Symbol extraction helps reuse checks but does not directly explain one-line pass-through value or nearby value markers.

Deletion/consolidation attempted:
No fanout/barrel/directory density rules; detector limited to one-line forwarders with explicit negative markers.

Chosen path:
High-confidence direct-forwarder detector with marker-based exemptions for validation, compatibility, retry, instrumentation, adapters, and framework overrides.

Rejected simpler paths:
Topology scoring, generic over-modularization rules, hard blockers, AST framework, and whole-repo wrapper counting.

Compatibility impact:
CLI, hook commands, python3 -B -S execution, zero dependencies, copied/global install, repo-local install, and Claude/Codex symmetry are preserved. Advisory findings do not affect ok, legacy warnings, checks, hardRules, empty text output, or fail_on_quality_warnings.

Verification:
See VERIFY.log. Focused tests cover Python/TS/Go hits and value-marker/framework non-hits.

Calibration rule:
Warning/advisory-only PR. Focused fixtures and dogfood are sufficient for landing. Hard-failure promotion requires fresh current-corpus per-rule attribution and FP below duplicate-block baseline.

Rollback path:
Delete wrapper helper(s), run_quality_gate population call, docs, and focused tests. P0 fields remain.


---
Stack position: `v13/p3-wrapper-value` targeting `v13/p2-failure-contract`. Source stack: `lean_gate_v13_pr_stack (2).zip`. Base commit: `0bb9ba4197bc2006a895c88190480c17738dd413`.