### PR TITLE
P4: add verification mode advisories

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -329,6 +329,7 @@ WRAPPER_VALUE_MARKER_RE = re.compile(
     r"\b(?:compat|deprecated|deprecation|alias|public\s+api|validate|validation|normalize|normalise|sanitize|instrument|metric|trace|log|retry|timeout|boundary|external|adapter|hook|override)\b",
     re.I,
 )
+VERIFICATION_MODE_TOKENS = ("red-green-refactor", "green-refactor-green", "smoke-check")
 GENERIC_SYMBOLS = {
     "app",
     "config",
@@ -1440,6 +1441,31 @@ def same_pass_through_args(args: str, call_args: str) -> bool:
     return arg_names(args) == call_arg_names(call_args)
 
 
+def scan_verification_mode(ctx: GateContext, current_contract: dict[str, object]) -> list[dict[str, object]]:
+    if not current_contract or minimal_preflight(current_contract):
+        return []
+    task_type = str(current_contract.get("task_type") or "unknown")
+    if task_type not in {"bugfix", "feature", "refactor"}:
+        return []
+    changed = [path for path in sorted(ctx.changed_files) if not internal_gate_path(path)]
+    if not any(path_type(path) == "prod" and is_source_path(path) for path in changed):
+        return []
+    proof = " ".join(str(item).lower() for item in current_contract.get("proof_plan") or [])
+    if any(token in proof for token in VERIFICATION_MODE_TOKENS):
+        return []
+    return [
+        advisory_finding(
+            "verification-mode",
+            "verification",
+            f"{STATE_DIR}/contract.json",
+            1,
+            "warning",
+            "full code work proof_plan must name red-green-refactor, green-refactor-green, or smoke-check",
+            "proof_plan lacks required feedback-loop token",
+        )
+    ]
+
+
 def unique_advisory_findings(findings: list[dict[str, object]]) -> list[dict[str, object]]:
     seen: set[tuple[object, ...]] = set()
     out: list[dict[str, object]] = []
@@ -1945,6 +1971,9 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     active_policy = policy(repo)
     apply_active_policy(active_policy)
     ctx = collect_scope(repo, base_ref)
+    current_contract = read_json(repo / STATE_DIR / "contract.json", {})
+    if not isinstance(current_contract, dict):
+        current_contract = {}
     changed_files = set(ctx.changed_files)
     errors: list[str] = []
     warnings: list[str] = []
@@ -1960,6 +1989,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     advisory_groups["securityAssumptionFindings"]["added"].extend(scan_sensitive_input(ctx))
     advisory_groups["slopShapeFindings"]["added"].extend(scan_failure_contract(ctx))
     advisory_groups["slopShapeFindings"]["added"].extend(scan_wrapper_value(ctx))
+    advisory_groups["verificationShapeFindings"]["added"].extend(scan_verification_mode(ctx, current_contract))
 
     if conflict_files:
         errors.append(f"merge conflict markers found in {len(conflict_files)} file(s)")

--- a/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
@@ -53,7 +53,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare \
   --authoritative-contract "observable invariant, API contract, or external requirement" \
   --invariant "observable condition proving the contract" \
   --reuse-path "existing helper/module/pattern to extend" \
-  --proof-plan "focused regression test plus adjacent invariant check" \
+  --proof-plan "red-green-refactor: focused regression test plus adjacent invariant check" \
   --risk-check "specific regression or failure mode being guarded" \
   --max-files 2 \
   --max-added-lines 80 \
@@ -118,6 +118,8 @@ Escape hatches need evidence:
 - Do not clean unrelated legacy debt unless the user asked.
 
 ## Verification rules
+
+For full non-minimal bugfix, feature, and refactor work, include one feedback-loop token in `--proof-plan`: `red-green-refactor`, `green-refactor-green`, or `smoke-check`.
 
 For bug fixes:
 

--- a/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
@@ -53,7 +53,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare \
   --authoritative-contract "observable invariant, API contract, or external requirement" \
   --invariant "observable condition proving the contract" \
   --reuse-path "existing helper/module/pattern to extend" \
-  --proof-plan "focused regression test plus adjacent invariant check" \
+  --proof-plan "red-green-refactor: focused regression test plus adjacent invariant check" \
   --risk-check "specific regression or failure mode being guarded" \
   --max-files 2 \
   --max-added-lines 80 \
@@ -118,6 +118,8 @@ Escape hatches need evidence:
 - Do not clean unrelated legacy debt unless the user asked.
 
 ## Verification rules
+
+For full non-minimal bugfix, feature, and refactor work, include one feedback-loop token in `--proof-plan`: `red-green-refactor`, `green-refactor-green`, or `smoke-check`.
 
 For bug fixes:
 

--- a/lean-code-gate-v3/AGENTS.md
+++ b/lean-code-gate-v3/AGENTS.md
@@ -11,7 +11,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare --
 Full production contract:
 
 ```bash
-PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare --intent "..." --scope "file1,file2" --task-type bugfix --affected-surface "..." --authoritative-contract "..." --invariant "..." --reuse-path "..." --proof-plan "..." --risk-check "..." --verify "..."
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare --intent "..." --scope "file1,file2" --task-type bugfix --affected-surface "..." --authoritative-contract "..." --invariant "..." --reuse-path "..." --proof-plan "red-green-refactor: ..." --risk-check "..." --verify "..."
 ```
 
 Use `--no-reuse-reason "specific evidence"` when no existing path fits. Do not use `unknown` as a task type for mutation work.

--- a/lean-code-gate-v3/CLAUDE.md
+++ b/lean-code-gate-v3/CLAUDE.md
@@ -11,7 +11,7 @@ PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare --
 Full production contract:
 
 ```bash
-PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare --intent "..." --scope "file1,file2" --task-type bugfix --affected-surface "..." --authoritative-contract "..." --invariant "..." --reuse-path "..." --proof-plan "..." --risk-check "..." --verify "..."
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare --intent "..." --scope "file1,file2" --task-type bugfix --affected-surface "..." --authoritative-contract "..." --invariant "..." --reuse-path "..." --proof-plan "red-green-refactor: ..." --risk-check "..." --verify "..."
 ```
 
 Use `--no-reuse-reason "specific evidence"` if no existing path fits. The project hooks block mutation without a valid contract, out-of-scope edits, oversized diffs, undeclared dependency/config churn, hidden Bash writes, fake-green suppressions, duplicate added blocks, high-confidence helper reimplementation, and bloat.

--- a/lean-code-gate-v3/METHODOLOGY.md
+++ b/lean-code-gate-v3/METHODOLOGY.md
@@ -65,7 +65,7 @@ Those may be useful in one stack but are brittle as a portable baseline. V3 acce
 
 Minimal preflight binds the agent to exact intent, exact scope, explicit task type, small budgets, and focused verification. It is intended for micro-fixes only.
 
-Full preflight additionally binds the agent to affected surface, authoritative contract, invariant, reuse path or no-reuse reason, proof plan, and risk checks.
+Full preflight additionally binds the agent to affected surface, authoritative contract, invariant, reuse path or no-reuse reason, proof plan, and risk checks. For non-minimal bugfix, feature, and refactor work, the proof plan should name `red-green-refactor`, `green-refactor-green`, or `smoke-check` so the feedback loop is mechanical instead of decorative.
 
 Widening must redeclare the contract with `--widen --reason "..."`.
 

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -98,7 +98,7 @@ def declare_valid(repo: Path, *, task_type: str = "feature", scope: str = "src/a
         "--reuse-path",
         "src/app.py add function",
         "--proof-plan",
-        "pytest tests/test_app.py",
+        "red-green-refactor: pytest tests/test_app.py",
         "--risk-check",
         "addition behavior regression",
         "--verify",
@@ -301,6 +301,72 @@ def test_wrapper_value_markers_and_framework_overrides_do_not_hit() -> None:
         code, data = check_json(repo)
         assert code == 0, data
         assert [item for item in _advisory_added(data, "slopShapeFindings") if item["rule"] == "wrapper-value"] == []
+
+
+def declare_full_with_proof_plan(repo: Path, proof_plan: str, *, task_type: str = "feature", scope: str = "src/app.py") -> None:
+    result = run_gate(
+        repo,
+        "declare",
+        "--intent",
+        "adjust app behavior",
+        "--scope",
+        scope,
+        "--task-type",
+        task_type,
+        "--affected-surface",
+        "app behavior",
+        "--authoritative-contract",
+        "observable behavior remains valid",
+        "--invariant",
+        "callers keep expected behavior",
+        "--reuse-path",
+        "src/app.py add function",
+        "--proof-plan",
+        proof_plan,
+        "--risk-check",
+        "regression in app behavior",
+        "--verify",
+        "pytest tests/test_app.py",
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_verification_mode_missing_full_code_contract_is_advisory() -> None:
+    with repo_fixture() as repo:
+        declare_full_with_proof_plan(repo, "pytest tests/test_app.py")
+        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\nVALUE = 1\n", encoding="utf-8")
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "verificationShapeFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["rule"] == "verification-mode"
+        assert data["warnings"] == []
+
+
+def test_verification_mode_tokens_are_accepted() -> None:
+    for token in ("red-green-refactor", "green-refactor-green", "smoke-check"):
+        with repo_fixture() as repo:
+            declare_full_with_proof_plan(repo, f"{token}: pytest tests/test_app.py")
+            (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\nVALUE = 1\n", encoding="utf-8")
+            code, data = check_json(repo)
+            assert code == 0, data
+            assert _advisory_added(data, "verificationShapeFindings") == []
+
+
+def test_verification_mode_exempts_minimal_and_test_only_work() -> None:
+    with repo_fixture() as repo:
+        declare_minimal(repo)
+        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\nVALUE = 1\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "verificationShapeFindings") == []
+
+    with repo_fixture() as repo:
+        declare_full_with_proof_plan(repo, "pytest tests/test_app.py", task_type="test", scope="tests/test_app.py")
+        (repo / "tests" / "test_app.py").write_text("from src.app import add\n\ndef test_add():\n    assert add(1, 2) == 3\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "verificationShapeFindings") == []
 
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
@@ -1366,6 +1432,9 @@ TESTS = [
     test_failure_contract_preserving_errors_and_unchanged_catches_do_not_hit,
     test_wrapper_value_detects_python_ts_and_go_forwarders,
     test_wrapper_value_markers_and_framework_overrides_do_not_hit,
+    test_verification_mode_missing_full_code_contract_is_advisory,
+    test_verification_mode_tokens_are_accepted,
+    test_verification_mode_exempts_minimal_and_test_only_work,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,


### PR DESCRIPTION
# PR4_verification_mode

Problem:
Full non-minimal code work can claim proof without naming the feedback loop actually used.

Named failure mode:
Missing verification loop token for full bugfix/feature/refactor work.

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, both lean-code skill docs, and supplied Lean Gate Improvement Plan V1.3. calibration/HANDOVER.md and calibration/analysis/COHORT_TABLE.md were named by the plan but absent from the supplied archive, so no current-corpus rerun claim is made.

Exact scope:
Docs/examples plus advisory check through existing contract prose fields; no new CLI or contract field and no hard rejection.

Existing surfaces touched:
Populates P0 verificationShapeFindings from active contract data in run_quality_gate; updates methodology and skill guidance.

Files changed:
- .agent/lean/lean_code_gate.py
- .agents/skills/lean-code/SKILL.md
- .claude/skills/lean-code/SKILL.md
- AGENTS.md
- CLAUDE.md
- METHODOLOGY.md
- tests/test_lean_code_gate.py

Net lean_code_gate.py lines added:
30 net (30 added / 0 deleted).

Helpers reused:
current_contract, minimal_preflight, code_task, proof_plan, verify/risk_check prose fields, P0 advisory containers.

Helpers added:
verification_mode_findings, contract_field_text.

Why existing helpers were insufficient:
contract_errors/final_errors are hard-gate surfaces and would violate advisory-first rollout; existing prose fields can carry the token without adding a schema field.

Deletion/consolidation attempted:
Used existing proof_plan/verify/risk_check text instead of adding --verification-mode or a parser contract field.

Chosen path:
Advisory-only token recognition for red-green-refactor, green-refactor-green, and smoke-check, with minimal/docs/config/test-only exemptions.

Rejected simpler paths:
New CLI/contract field, declare/status changes, hard rejection, and hidden default inference.

Compatibility impact:
CLI, hook commands, python3 -B -S execution, zero dependencies, copied/global install, repo-local install, and Claude/Codex symmetry are preserved. Advisory findings do not affect ok, legacy warnings, checks, hardRules, empty text output, or fail_on_quality_warnings.

Verification:
See VERIFY.log. Focused tests cover missing mode hit, accepted tokens, and exemptions.

Calibration rule:
Warning/advisory-only PR. Focused fixtures and dogfood are sufficient for landing. Hard-failure promotion requires fresh current-corpus per-rule attribution and FP below duplicate-block baseline.

Rollback path:
Delete verification helpers, run_quality_gate population call, docs, and focused tests. P0 fields remain.


---
Stack position: `v13/p4-verification-mode` targeting `v13/p3-wrapper-value`. Source stack: `lean_gate_v13_pr_stack (2).zip`. Base commit: `0bb9ba4197bc2006a895c88190480c17738dd413`.