### PR TITLE
P6: add advisory delta reporting

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1503,6 +1503,86 @@ def production_shaped_proof_finding(path: str, lines: list[tuple[int, str]]) -> 
     return None
 
 
+def apply_advisory_delta(ctx: GateContext, groups: dict[str, dict[str, list[dict[str, object]]]]) -> None:
+    for rel_path in sorted(ctx.changed_files):
+        if internal_gate_path(rel_path) or is_binary_path(rel_path):
+            continue
+        base_text = read_git_file(ctx.repo, ctx.base_for_file, rel_path)
+        current_text = read_file(ctx.repo / rel_path)
+        for group_name in ADVISORY_GROUP_NAMES:
+            base = advisory_snapshot_findings(rel_path, base_text, group_name)
+            current = advisory_snapshot_findings(rel_path, current_text, group_name)
+            add_advisory_delta(groups[group_name], base, current)
+
+
+def advisory_snapshot_findings(path: str, text: str | None, group_name: str) -> list[dict[str, object]]:
+    if text is None:
+        return []
+    lines = list(enumerate(text.splitlines(), 1))
+    findings: list[dict[str, object]] = []
+    if group_name == "securityAssumptionFindings" and is_production_source_path(path):
+        findings.extend(scan_sensitive_input_lines(path, lines))
+    elif group_name == "slopShapeFindings" and is_source_path(path):
+        if language_for_path(path) == "javascript":
+            findings.extend(scan_failure_contract_lines(path, lines, text))
+        if is_production_source_path(path):
+            findings.extend(scan_wrapper_value_lines(path, lines))
+    elif group_name == "verificationShapeFindings" and (path_type(path) == "test" or is_test_like_path(path)):
+        finding = production_shaped_proof_finding(path, lines)
+        if finding:
+            findings.append(finding)
+    return unique_advisory_findings(findings)
+
+
+def add_advisory_delta(group: dict[str, list[dict[str, object]]], base: list[dict[str, object]], current: list[dict[str, object]]) -> None:
+    base_keys = {advisory_delta_key(finding): finding for finding in base}
+    current_keys = {advisory_delta_key(finding): finding for finding in current}
+    group["resolved"].extend(base_keys[key] for key in sorted(base_keys.keys() - current_keys.keys()))
+    base_counts = advisory_delta_counts(base)
+    current_counts = advisory_delta_counts(current)
+    for key in sorted(set(base_counts) | set(current_counts)):
+        before = base_counts.get(key, 0)
+        after = current_counts.get(key, 0)
+        if before and after and after > before:
+            group["worsened"].append(advisory_delta_summary(key, "worsened", before, after))
+        elif before and after and after < before:
+            group["improved"].append(advisory_delta_summary(key, "improved", before, after))
+
+
+def advisory_delta_key(finding: dict[str, object]) -> tuple[object, ...]:
+    return (finding.get("rule"), finding.get("family"), finding.get("path"), finding.get("line"), finding.get("message"))
+
+
+def advisory_delta_count_key(finding: dict[str, object]) -> tuple[str, str, str, str]:
+    return (
+        str(finding.get("rule") or "advisory-delta"),
+        str(finding.get("family") or "advisory"),
+        str(finding.get("path") or "unknown"),
+        str(finding.get("severity") or "warning"),
+    )
+
+
+def advisory_delta_counts(findings: list[dict[str, object]]) -> dict[tuple[str, str, str, str], int]:
+    counts: dict[tuple[str, str, str, str], int] = {}
+    for finding in findings:
+        key = advisory_delta_count_key(finding)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def advisory_delta_summary(key: tuple[str, str, str, str], bucket: str, before: int, after: int) -> dict[str, object]:
+    rule, family, path, severity = key
+    return advisory_finding(
+        rule,
+        family,
+        path,
+        0,
+        severity,
+        f"advisory finding count {bucket}: {before} -> {after}",
+        f"base_count={before}; current_count={after}",
+    )
+
+
 def unique_advisory_findings(findings: list[dict[str, object]]) -> list[dict[str, object]]:
     seen: set[tuple[object, ...]] = set()
     out: list[dict[str, object]] = []
@@ -2028,6 +2108,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     advisory_groups["slopShapeFindings"]["added"].extend(scan_wrapper_value(ctx))
     advisory_groups["verificationShapeFindings"]["added"].extend(scan_verification_mode(ctx, current_contract))
     advisory_groups["verificationShapeFindings"]["added"].extend(scan_production_shaped_proof(ctx))
+    apply_advisory_delta(ctx, advisory_groups)
 
     if conflict_files:
         errors.append(f"merge conflict markers found in {len(conflict_files)} file(s)")

--- a/lean-code-gate-v3/METHODOLOGY.md
+++ b/lean-code-gate-v3/METHODOLOGY.md
@@ -86,7 +86,7 @@ The final quality gate inspects the changed source scope and fails on:
 
 The advisory surface also reports sensitive-input reads when changed production code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value. TypeScript and JavaScript catch/reject paths are advisory findings when they only log, stringify unknown errors, or return cheap defaults such as `null`, `undefined`, `false`, empty arrays, empty objects, or empty strings. New one-line forwarding wrappers are advisory findings when no nearby validation, normalization, instrumentation, retry, compatibility, deprecation, or external-boundary value is visible. Large mock-heavy tests with weak assertions and no visible production entrypoint, parser, CLI, hook payload, public API, or fixture are verification advisory findings.
 
-Warnings are emitted for moderate bloat and weaker reuse signals. Projects can promote warnings to failures in `.agent/lean/policy.json`.
+Advisory findings are bucketed as added, resolved, improved, or worsened for touched files. Warnings are emitted for moderate bloat and weaker reuse signals. Projects can promote legacy warnings to failures in `.agent/lean/policy.json`; advisory findings stay out of that promotion path.
 
 ## Operating guidance
 

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -407,6 +407,52 @@ def test_production_shaped_proof_allows_entrypoint_fixture_and_assertion_rich_te
         assert code == 0, data
         assert [item for item in _advisory_added(data, "verificationShapeFindings") if item["rule"] == "production-shaped-proof"] == []
 
+
+def test_delta_reporting_resolved_security_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "security.py").write_text("import os\nTOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed sensitive")
+        (repo / "src" / "security.py").write_text("VALUE = 1\n", encoding="utf-8")
+        code, data = check_json(repo)
+        group = data["securityAssumptionFindings"]
+        assert code == 0, data
+        assert group["added"] == []
+        assert len(group["resolved"]) == 1
+
+
+def test_delta_reporting_improved_security_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "security.py").write_text(
+            "import os\nTOKEN = os.getenv('API_KEY')\nKEY = open('/home/user/.ssh/id_rsa').read()\n", encoding="utf-8"
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed two sensitive")
+        (repo / "src" / "security.py").write_text("import os\nTOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
+        code, data = check_json(repo)
+        group = data["securityAssumptionFindings"]
+        assert code == 0, data
+        assert len(group["improved"]) == 1
+        assert "2 -> 1" in group["improved"][0]["message"]
+        assert group["improved"][0]["line"] == 0
+
+
+def test_delta_reporting_worsened_security_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "security.py").write_text("import os\nTOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed one sensitive")
+        (repo / "src" / "security.py").write_text(
+            "import os\nTOKEN = os.getenv('API_KEY')\nKEY = open('/home/user/.ssh/id_rsa').read()\n", encoding="utf-8"
+        )
+        code, data = check_json(repo)
+        group = data["securityAssumptionFindings"]
+        assert code == 0, data
+        assert len(group["added"]) == 1
+        assert len(group["worsened"]) == 1
+        assert "1 -> 2" in group["worsened"][0]["message"]
+        assert group["worsened"][0]["line"] == 0
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1476,6 +1522,9 @@ TESTS = [
     test_verification_mode_exempts_minimal_and_test_only_work,
     test_production_shaped_proof_warns_on_mock_heavy_weak_test,
     test_production_shaped_proof_allows_entrypoint_fixture_and_assertion_rich_tests,
+    test_delta_reporting_resolved_security_advisory,
+    test_delta_reporting_improved_security_advisory,
+    test_delta_reporting_worsened_security_advisory,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,


### PR DESCRIPTION
# PR6_delta_reporting

Problem:
Agents see advisory hits but not whether touched work added, resolved, worsened, or improved those shapes.

Named failure mode:
Missing advisory movement context for touched files.

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, both lean-code skill docs, and supplied Lean Gate Improvement Plan V1.3. calibration/HANDOVER.md and calibration/analysis/COHORT_TABLE.md were named by the plan but absent from the supplied archive, so no current-corpus rerun claim is made.

Exact scope:
Touched changed files only; advisory families only; no legacy R-rule backfill, no findingCounts, no repo-wide scoring.

Existing surfaces touched:
Uses collect_scope/read_git_file to compare base/current touched-file advisory snapshots and populate P0 resolved/improved/worsened buckets.

Files changed:
- .agent/lean/lean_code_gate.py
- METHODOLOGY.md
- tests/test_lean_code_gate.py

Net lean_code_gate.py lines added:
81 net (81 added / 0 deleted).

Helpers reused:
read_git_file, collect_scope base_for_file, existing P1-P5 scan helpers, unique_advisory_findings.

Helpers added:
apply_advisory_delta, advisory_snapshot_findings, add_advisory_delta, advisory_delta_key, advisory_delta_count_key, advisory_delta_counts, advisory_delta_summary.

Why existing helpers were insufficient:
P1-P5 only populate added findings. Exact finding-level movement would be larger; count summaries avoid the earlier misleading sample=current[0] attribution.

Deletion/consolidation attempted:
Kept movement to touched-file snapshots and count summaries keyed by rule/family/path/severity with line 0, not per-rule corpus accounting.

Chosen path:
Cheap base-vs-current advisory count bucketing for resolved/improved/worsened while keeping added findings from the primary detectors.

Rejected simpler paths:
Whole-repo scans, adapting R-1..R-6, exact per-finding attribution machinery, and calibration-only scoring in runtime.

Compatibility impact:
CLI, hook commands, python3 -B -S execution, zero dependencies, copied/global install, repo-local install, and Claude/Codex symmetry are preserved. Advisory findings do not affect ok, legacy warnings, checks, hardRules, empty text output, or fail_on_quality_warnings.

Verification:
See VERIFY.log. Focused tests cover resolved, improved, and worsened advisory deltas; samples use line 0 to avoid fake precision.

Calibration rule:
Warning/advisory-only PR. Focused fixtures and dogfood are sufficient for landing. Hard-failure promotion requires fresh current-corpus per-rule attribution and FP below duplicate-block baseline.

Rollback path:
Delete delta helpers, the apply_advisory_delta call, docs, and focused tests. P0 fields remain.


---
Stack position: `v13/p6-delta-reporting` targeting `v13/p5-production-shaped-proof`. Source stack: `lean_gate_v13_pr_stack (2).zip`. Base commit: `0bb9ba4197bc2006a895c88190480c17738dd413`.