### PR TITLE
P1: add sensitive input advisories

### DIFF
--- a/.agent/lean/lean_code_gate.py
+++ b/.agent/lean/lean_code_gate.py
@@ -1,0 +1,2437 @@
+#!/usr/bin/env python3
+"""Lean Code Gate v3.
+
+Deterministic contract, scope, verification, and changed-code quality gates for
+coding agents. The script is intentionally dependency-free so hooks can run in a
+fresh repository without importing project packages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import signal
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+VERSION = "3.0.0"
+STATE_DIR = ".agent/lean/state"
+POLICY_FILE = ".agent/lean/policy.json"
+
+DEFAULT_POLICY: dict[str, object] = {
+    "default_max_files": 3,
+    "default_max_added_lines": 120,
+    "default_max_changed_lines": 240,
+    "require_verify_after_mutation": True,
+    "require_bugfix_test_change": True,
+    "require_explicit_task_type": True,
+    "require_preflight_for_code": True,
+    "require_reuse_path_for_code": True,
+    "allow_minimal_preflight": True,
+    "minimal_preflight_max_files": 2,
+    "minimal_preflight_max_added_lines": 30,
+    "minimal_preflight_max_changed_lines": 80,
+    "minimal_preflight_task_types": ["bugfix", "test", "docs", "config"],
+    "block_broad_scope": True,
+    "block_dependency_changes_without_flag": True,
+    "block_config_changes_without_flag": False,
+    "block_hidden_bash_writes": True,
+    "run_quality_gate_on_stop": True,
+    "fail_on_quality_warnings": False,
+    # max_design_markers: 4 (was 2): requires all 4 DESIGN_RE categories to
+    # match. Calibrated against Pydantic's _generate_schema.py (2922 lines,
+    # density 1.4/100, was firing as FP). Combined with density gating >= 3.0
+    # for files >= 100 lines, allows typing-heavy frameworks while still
+    # flagging gratuitous abstraction in small surfaces (4 markers in 7 lines
+    # = 57/100 density still trips the small-file branch).
+    "max_design_markers": 4,
+    "max_design_marker_density_per_100_lines": 3.0,
+    "allowed_broad_globs": ["src/**", "lib/**", "app/**", "tests/**", "test/**"],
+    "bloat_new_file_warn_lines": 500,
+    "bloat_new_file_error_lines": 800,
+    "bloat_large_file_lines": 1500,
+    "bloat_large_file_must_shrink": False,
+    "bloat_large_file_growth_lines": 80,
+    "bloat_file_growth_lines": 250,
+    "bloat_total_added_warn_lines": 500,
+    "bloat_total_added_error_lines": 1000,
+    "bloat_add_delete_warn_ratio": 4,
+    "bloat_add_delete_error_ratio": 6,
+    "quality_max_index_files": 4000,
+    "quality_max_index_file_bytes": 500000,
+    "quality_max_index_symbols": 25000,
+    "reuse_detector_mode": "conservative",
+    "reuse_error_score": 90,
+    "reuse_warning_score": 45,
+    "reuse_min_duplicate_count": 3,
+    "reuse_suppress_private_public_siblings": True,
+    "framework_override_names": [
+        "validate", "clean", "save", "save_model", "save_formset",
+        "get_queryset", "get_form", "get_form_kwargs", "get_context_data",
+        "get_object", "get_serializer", "get_serializer_class",
+        "as_sql", "as_dict", "as_view",
+        "to_python", "to_internal_value", "to_representation",
+        "form_valid", "form_invalid",
+        "__init__", "__call__", "__enter__", "__exit__",
+        "__iter__", "__next__", "__len__", "__contains__",
+        "__getitem__", "__setitem__", "__delitem__",
+        "__set__", "__get__", "__delete__", "__set_name__",
+        "__hash__", "__eq__", "__lt__", "__gt__", "__le__", "__ge__",
+        "__repr__", "__str__", "__bool__",
+        "componentDidMount", "componentDidUpdate", "componentWillUnmount",
+        "render", "shouldComponentUpdate", "getDerivedStateFromProps",
+        "ngOnInit", "ngOnDestroy", "ngOnChanges",
+    ],
+    "excluded_path_globs": [
+        "**/migrations/**",
+        "**/generated/**",
+        "**/__generated__/**",
+        "**/_generated/**",
+        "**/*.pb.go",
+        "**/*.pb.cc",
+        "**/*.pb.h",
+        "**/*.pb.py",
+        "**/*_pb2.py",
+        "**/*_pb2_grpc.py",
+        "**/*.generated.*",
+        "**/dist-cjs/**",
+        "**/dist-es/**",
+        "**/dist-types/**",
+        "clients/*/src/commands/**",
+        "clients/*/src/models/**",
+        "clients/*/src/schemas/**",
+        "clients/*/src/protocols/**",
+        "clients/*/src/waiters/**",
+        "**/admin/static/admin/**",
+        "**/static/admin/**",
+        "docs_src/**",
+        "**/python_version.py",
+    ],
+}
+
+MUTATING_TOOLS = {"Edit", "MultiEdit", "Write", "NotebookEdit", "apply_patch", "ApplyPatch"}
+DEPENDENCY_FILES = {
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "bun.lockb",
+    "bun.lock",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "pyproject.toml",
+    "poetry.lock",
+    "Pipfile",
+    "Pipfile.lock",
+    "go.mod",
+    "go.sum",
+    "Cargo.toml",
+    "Cargo.lock",
+    "Gemfile",
+    "Gemfile.lock",
+    "composer.json",
+    "composer.lock",
+}
+CONFIG_GLOBS = [
+    ".github/workflows/*",
+    "*.config.js",
+    "*.config.ts",
+    "*.config.mjs",
+    "*.config.cjs",
+    "tsconfig*.json",
+    "vite.config.*",
+    "webpack.config.*",
+    "jest.config.*",
+    "vitest.config.*",
+    "eslint.config.*",
+    ".eslintrc*",
+    ".prettierrc*",
+    "mypy.ini",
+    "ruff.toml",
+    ".ruff.toml",
+    "pytest.ini",
+    "tox.ini",
+]
+TEST_GLOBS = [
+    "tests/**",
+    "test/**",
+    "**/*_test.*",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "**/test_*.py",
+    "**/__tests__/**",
+]
+BROAD_SCOPE = {"*", "**", "**/*", ".", "./", "./**", "./**/*", "src", "lib", "app"}
+PLACEHOLDER_TEXT = {"", "n/a", "na", "none", "unknown", "tbd", "todo", "placeholder", "same", "existing"}
+VERIFY_HINTS = (
+    "test",
+    "pytest",
+    "vitest",
+    "jest",
+    "mocha",
+    "go test",
+    "cargo test",
+    "mvn test",
+    "gradle test",
+    "ruff",
+    "eslint",
+    "tsc",
+    "mypy",
+    "black --check",
+    "prettier --check",
+    "npm run lint",
+    "pnpm lint",
+    "yarn lint",
+    "lean_code_gate.py check",
+)
+HIDDEN_WRITE_RE = re.compile(
+    r"(^|[;&|]\s*)(cat\s+>\s|tee\s|printf\s+.*>\s|echo\s+.*>\s)|"
+    r"\b(sed\s+-i|perl\s+-pi|rm|mv|cp|mkdir|touch|chmod|chown)\b|"
+    r"\bgit\s+(checkout|reset|clean|apply|am|rm|mv|add|commit|rebase|merge)\b|"
+    r"\b(npm\s+(install|i|add)|pnpm\s+add|yarn\s+add|bun\s+add|pip\s+install|poetry\s+add|uv\s+add|go\s+get|cargo\s+add)\b|"
+    r"\b(write_text|write_bytes|open\(.{0,80},\s*['\"]w|fs\.writeFile|fs\.appendFile)\b",
+    re.S,
+)
+DESIGN_RE = [
+    (re.compile(r"\bclass\s+\w*(Factory|Builder|Manager|Registry|Strategy|Adapter|Provider)\b"), "pattern-named class"),
+    (re.compile(r"\bfunc\s+(?:\([^)]*\)\s*)?New\w*(Factory|Builder|Manager|Registry|Strategy|Adapter|Provider)\b"), "pattern-named factory function"),
+    # Rust pattern intentionally broader than Python/JS (State/Context/Scope
+    # added). Rust's type-alias system is commonly used for abstraction
+    # layering (e.g., pub type ParserState, pub type RequestContext) in ways
+    # the Python/JS class pattern isn't. Asymmetry is calibrated, not a bug.
+    (re.compile(r"\bpub\s+type\s+\w*(State|Manager|Strategy|Adapter|Provider|Factory|Builder|Registry|Context|Scope)\b"), "rust type-alias abstraction"),
+    (re.compile(r"\b(Abstract[A-Z]\w*|Base[A-Z]\w*)\b"), "abstract/base type"),
+    (re.compile(r"\b(Protocol|ABC|abc\.ABC|TypeVar|Generic\[)\b"), "generic typing abstraction"),
+    (re.compile(r"\b(plugin|middleware|strategy|extensible|extension point|feature[_ -]?flag)\b", re.I), "extension machinery"),
+]
+
+SOURCE_EXTENSIONS = {
+    ".cjs",
+    ".cts",
+    ".go",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".mts",
+    ".php",
+    ".py",
+    ".rb",
+    ".rs",
+    ".sh",
+    ".ts",
+    ".tsx",
+}
+EXCLUDE_DIRS = {
+    ".cache",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".next",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "build",
+    "coverage",
+    "dist",
+    "node_modules",
+    "target",
+    "vendor",
+    "venv",
+}
+TEST_MARKERS = (
+    "/__fixtures__/",
+    "/__mocks__/",
+    "/__snapshots__/",
+    "/__tests__/",
+    "/fixture/",
+    "/fixtures/",
+    "/generated/",
+    "/snapshots/",
+    "/test/",
+    "/tests/",
+)
+BINARY_EXTENSIONS = {
+    ".avif",
+    ".bin",
+    ".bmp",
+    ".gif",
+    ".ico",
+    ".jpeg",
+    ".jpg",
+    ".lock",
+    ".map",
+    ".pdf",
+    ".png",
+    ".snap",
+    ".svg",
+    ".webp",
+    ".zip",
+}
+GENERAL_ESCAPE_RULES = [
+    re.compile(r"\b(?:" + "|".join(["TO" + "DO", "FIX" + "ME", "HA" + "CK"]) + r")\b", re.I),
+    re.compile("@ts" + r"-ignore\b"),
+    re.compile("@ts" + r"-expect-error\b"),
+    re.compile("eslint" + r"-disable\b"),
+    re.compile(r"#\s*type:\s*" + "ignore" + r"\b", re.I),
+    re.compile(r"#\s*" + "no" + r"qa\b", re.I),
+    re.compile(r"\|\|\s*true\b"),
+]
+PYTHON_ESCAPE_RULES = [
+    re.compile(r"\btyping\." + "An" + "y" + r"\b"),
+    re.compile(r":\s*" + "An" + "y" + r"\b"),
+    re.compile(r"\b" + "ca" + "st" + r"\s*\("),
+    re.compile(r"^\s*except\s*:\s*$"),
+    re.compile(r"^\s*except\s+Exception\s*:\s*pass\s*$"),
+]
+TS_ESCAPE_RULES = [
+    re.compile(r":\s*any\b"),
+    re.compile(r"<\s*any\s*>"),
+    re.compile(r"\bas\s+any\b"),
+    re.compile(r"\bas\s+unknown\s+as\b"),
+]
+EMPTY_CATCH_RULES = [
+    re.compile(r"\bcatch\s*\([^)]*\)\s*\{\s*\}", re.S),
+    re.compile(r"\bcatch\s*\{\s*\}", re.S),
+    re.compile(r"\.catch\s*\(\s*(?:async\s*)?\([^)]*\)\s*=>\s*\{\s*\}\s*\)", re.S),
+    re.compile(r"except\s+Exception\s*:\s*\n\s*pass\b", re.S),
+    re.compile(r"except\s*:\s*\n\s*pass\b", re.S),
+]
+SENSITIVE_SOURCE_RULES = [
+    (re.compile(r"\b(?:os\.getenv|os\.environ\s*(?:\.get|\[)|process\.env\s*(?:\.|\[)|Deno\.env\.get|std::env::var|os\.Getenv|getenv\s*\()"), "environment-read"),
+    (re.compile(r"\bgit\s+(?:remote\s+get-url|config\s+--get\s+remote\.)"), "git-remote-url-read"),
+    (re.compile(r"(?:^|[/\\])(?:\.netrc|\.ssh|\.aws)(?:[/\\]|$)|\b(?:id_rsa|id_ed25519|known_hosts)\b"), "credential-file-read"),
+    (re.compile(r"\b(?:keyring\.|keytar\.|SecretStorage|security\s+find-generic-password)"), "keyring-read"),
+    (re.compile(r"""(?:\b(?:req|request)\.headers|\bheaders)\s*(?:\.get\s*\(\s*['"](?:authorization|cookie|set-cookie)['"]|\[\s*['"](?:Authorization|Cookie|Set-Cookie)['"]\s*\])|\bgetHeader\s*\(\s*['"](?:Authorization|Cookie|Set-Cookie)['"]""", re.I), "auth-header-read"),
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private-key-material"),
+]
+SENSITIVE_SINK_RULES = [
+    (re.compile(r"\b(?:console\.(?:log|error|warn)|print|fmt\.Print(?:f|ln)?|println!|eprintln!|logger?\.|log\.)\s*\("), "log-or-console"),
+    (re.compile(r"\b(?:JSON\.stringify|json\.dumps|pickle\.dump|yaml\.dump|serialize|snapshot)\b|\b(?:telemetry|metrics)\.(?:track|emit|record|log)\s*\("), "serialization-or-telemetry"),
+    (re.compile(r"""\b(?:write_text|write_bytes|writeFile|appendFile|fs\.(?:writeFile|appendFile)|open\s*\([^)]*['"]w)\b"""), "persistence"),
+]
+SENSITIVE_IDENTIFIER_RE = re.compile(r"^(?:\s*(?:const|let|var)\s+)?([A-Za-z_$][\w$]*)\s*(?::=|=)")
+GENERIC_SYMBOLS = {
+    "app",
+    "config",
+    "create",
+    "delete",
+    "get",
+    "handler",
+    "index",
+    "init",
+    "load",
+    "main",
+    "post",
+    "put",
+    "render",
+    "run",
+    "save",
+    "setup",
+    "start",
+    "stop",
+    "update",
+}
+REUSE_ACTION_TOKENS = {
+    "build",
+    "dedupe",
+    "deduplicate",
+    "fetch",
+    "filter",
+    "format",
+    "load",
+    "map",
+    "normalize",
+    "parse",
+    "read",
+    "resolve",
+    "retry",
+    "sanitize",
+    "sync",
+    "validate",
+    "walk",
+    "write",
+}
+GENERIC_MATCH_TOKENS = {
+    "and",
+    "code",
+    "content",
+    "data",
+    "for",
+    "get",
+    "handle",
+    "has",
+    "is",
+    "load",
+    "parse",
+    "read",
+    "request",
+    "response",
+    "result",
+    "results",
+    "signal",
+    "state",
+    "text",
+    "url",
+    "value",
+    "wait",
+    "with",
+}
+RISKY_BLOCK_RULE = re.compile(
+    r"\b(?:for|while|map|filter|reduce|retry|fetch|read|write|parse|normalize|validate|format|resolve|dedupe|deduplicate)\b",
+    re.I,
+)
+SYMBOL_PATTERNS = {
+    "python": [
+        ("function", re.compile(r"^\s*(?:async\s+)?def\s+([A-Za-z_][\w]*)\s*\(")),
+        ("class", re.compile(r"^\s*class\s+([A-Za-z_][\w]*)\s*(?:\(|:)")),
+    ],
+    "javascript": [
+        ("function", re.compile(r"^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(")),
+        ("class", re.compile(r"^\s*(?:export\s+)?class\s+([A-Za-z_$][\w$]*)\b")),
+        (
+            "function",
+            re.compile(
+                r"^\s*(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>"
+            ),
+        ),
+    ],
+    "go": [("function", re.compile(r"^\s*func\s+(?:\([^)]*\)\s*)?([A-Za-z_][\w]*)\s*\("))],
+    "rust": [
+        ("function", re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z_][\w]*)\s*\(")),
+        ("type", re.compile(r"^\s*(?:pub\s+)?(?:struct|enum|trait)\s+([A-Za-z_][\w]*)\b")),
+    ],
+    "shell": [("function", re.compile(r"^\s*(?:function\s+)?([A-Za-z_][\w-]*)\s*\(\s*\)"))],
+    "php": [
+        ("function", re.compile(r"^\s*(?:public|private|protected|static|\s)*function\s+([A-Za-z_][\w]*)\s*\(")),
+        ("class", re.compile(r"^\s*class\s+([A-Za-z_][\w]*)\b")),
+    ],
+    "ruby": [
+        ("function", re.compile(r"^\s*def\s+([A-Za-z_][\w!?=]*)\b")),
+        ("class", re.compile(r"^\s*class\s+([A-Za-z_][\w:]*)\b")),
+    ],
+}
+
+
+@dataclass(frozen=True)
+class Numstat:
+    added: int
+    deleted: int
+    path: str
+
+
+@dataclass(frozen=True)
+class SymbolDef:
+    name: str
+    path: str
+    line: int
+    kind: str
+    language: str
+    tokens: tuple[str, ...]
+    source: str
+    context_boost: int = 0
+
+
+@dataclass(frozen=True)
+class ReuseFinding:
+    severity: str
+    score: int
+    new_symbol: str
+    new_file: str
+    new_line: int
+    existing_symbol: str
+    existing_file: str
+    existing_line: int
+    reason: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "severity": self.severity,
+            "score": self.score,
+            "newSymbol": self.new_symbol,
+            "newFile": self.new_file,
+            "newLine": self.new_line,
+            "existingSymbol": self.existing_symbol,
+            "existingFile": self.existing_file,
+            "existingLine": self.existing_line,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class GateContext:
+    repo: Path
+    changed_files: set[str]
+    untracked: set[str]
+    raw_diff: str
+    base_for_file: str
+    numstats: list[Numstat]
+    added_lines: dict[str, list[tuple[int, str]]]
+
+    def added_lines_with_untracked(self, *, production_only: bool) -> dict[str, list[tuple[int, str]]]:
+        out = {path: list(lines) for path, lines in self.added_lines.items()}
+        predicate = is_production_source_path if production_only else is_source_path
+        for rel_path in sorted(self.untracked):
+            if predicate(rel_path):
+                text = read_file(self.repo / rel_path)
+                if text is not None:
+                    out.setdefault(rel_path, []).extend((idx, line) for idx, line in enumerate(text.splitlines(), 1))
+        return out
+
+
+def run_process(cmd: list[str], cwd: Path, timeout: int = 15) -> subprocess.CompletedProcess[str]:
+    try:
+        # text=True implies strict utf-8 decoding which crashes when git diff
+        # output contains non-utf-8 bytes (e.g. binary patches in long
+        # multi-commit windows). Use encoding+errors='replace' instead so
+        # the gate can keep running and just lose offending bytes.
+        process = subprocess.Popen(
+            cmd,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            errors="replace",
+            start_new_session=(os.name != "nt"),
+        )
+        stdout, stderr = process.communicate(timeout=timeout)
+        return subprocess.CompletedProcess(cmd, process.returncode, stdout, stderr)
+    except FileNotFoundError as exc:
+        return subprocess.CompletedProcess(cmd, 127, "", str(exc))
+    except subprocess.TimeoutExpired:
+        if os.name != "nt":
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except OSError:
+                pass
+        else:
+            process.kill()
+        try:
+            stdout, stderr = process.communicate(timeout=3)
+        except subprocess.TimeoutExpired:
+            stdout, stderr = "", "process group did not terminate cleanly"
+        return subprocess.CompletedProcess(cmd, 124, stdout, stderr or "command timed out")
+
+
+def sh(cmd: list[str], cwd: Path, timeout: int = 15) -> subprocess.CompletedProcess[str]:
+    return run_process(cmd, cwd, timeout)
+
+
+def git_toplevel(start: Path) -> Path | None:
+    result = sh(["git", "rev-parse", "--show-toplevel"], start if start.is_dir() else start.parent)
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip()).resolve()
+    return None
+
+
+def repo_root(cwd: str | None = None) -> Path:
+    configured = os.environ.get("LEAN_CODE_GATE_REPO_ROOT")
+    if cwd:
+        payload_start = Path(cwd).expanduser()
+        if payload_start.exists():
+            payload_root = git_toplevel(payload_start.resolve())
+            if payload_root is not None:
+                return payload_root
+
+    start = Path(configured or cwd or os.getcwd()).expanduser()
+    if configured and not start.exists():
+        raise SystemExit(f"LEAN_CODE_GATE_REPO_ROOT does not exist: {start}")
+    if not configured and not start.exists():
+        start = Path(os.getcwd())
+    start = start.resolve()
+    configured_root = git_toplevel(start)
+    if configured_root is not None:
+        return configured_root
+    if configured:
+        raise SystemExit(f"LEAN_CODE_GATE_REPO_ROOT is not a git repository: {start}")
+    return start
+
+
+def tool_command(tool_input: dict[str, object]) -> str:
+    return str(tool_input.get("command") or tool_input.get("cmd") or "")
+
+
+def nested_git_roots(root: Path) -> list[Path]:
+    return sorted(path.parent.resolve() for path in root.rglob(".git") if path.resolve() != (root / ".git").resolve())
+
+
+def checked_hook_root(event: str | None, payload: dict[str, object], tool: str, tool_input: dict[str, object], *, require_unambiguous: bool = False) -> Path | None:
+    try:
+        return hook_root(payload, tool, tool_input, require_unambiguous=require_unambiguous)
+    except ValueError as error:
+        if event:
+            deny(event, str(error))
+        return None
+
+
+def hook_root(payload: dict[str, object], tool: str, tool_input: dict[str, object], *, require_unambiguous: bool = False) -> Path:
+    tool_cwd = str(tool_input.get("workdir") or tool_input.get("cwd") or "") or None
+    if tool_cwd:
+        return repo_root(tool_cwd)
+
+    root = repo_root(str(payload.get("cwd") or "") or None)
+    is_mutating = mutating(tool, tool_input)
+    if not is_mutating and not require_unambiguous:
+        return root
+
+    if is_mutating:
+        path_roots: set[Path] = set()
+        for value in facts(root, tool, tool_input).get("paths", []):
+            if isinstance(value, str):
+                path = (root / value).resolve()
+                found = git_toplevel(path if path.is_dir() else path.parent)
+                if found is not None and found != root and root in found.parents:
+                    path_roots.add(found)
+        if len(path_roots) == 1:
+            return next(iter(path_roots))
+        if len(path_roots) > 1:
+            raise ValueError("Lean Code Gate could not choose between nested target repos: " + ", ".join(str(path) for path in sorted(path_roots)))
+
+    if nested_git_roots(root):
+        raise ValueError(
+            "Lean Code Gate cannot resolve a unique target repo from controller folder "
+            f"{root}. Hook payload did not include tool workdir/cwd. Start the session "
+            "inside the target repo or use a hook runtime that passes tool workdir."
+        )
+
+    return root
+
+
+def stop_roots(payload: dict[str, object]) -> list[Path]:
+    root = repo_root(str(payload.get("cwd") or "") or None)
+    nested = nested_git_roots(root)
+    if not nested:
+        return [root]
+    target = active_state(root).get("target_root")
+    if isinstance(target, str) and (found := git_toplevel(Path(target).expanduser().resolve())) is not None and found != root and root in found.parents:
+        return [found]
+    return [root] if git_toplevel(root) == root else []
+
+
+def remember_target_root(payload: dict[str, object], root: Path) -> None:
+    controller = repo_root(str(payload.get("cwd") or "") or None)
+    if controller == root:
+        return
+    active = active_state(controller)
+    active["target_root"] = str(root.resolve())
+    write_json(active_path(controller), active)
+
+
+def hook_facts(payload: dict[str, object], root: Path, tool: str, tool_input: dict[str, object]) -> dict[str, object]:
+    change_facts = facts(root, tool, tool_input)
+    controller = repo_root(str(payload.get("cwd") or "") or None)
+    if controller != root and controller in root.parents:
+        prefix = root.relative_to(controller).as_posix() + "/"
+        change_facts["paths"] = [path.removeprefix(prefix) if isinstance(path, str) else path for path in change_facts.get("paths", [])]
+    return change_facts
+
+
+def git_common_dir(root: Path) -> Path:
+    result = sh(["git", "rev-parse", "--git-common-dir"], root, timeout=10)
+    if result.returncode != 0 or not result.stdout.strip():
+        return (root / ".git").resolve()
+    value = Path(result.stdout.strip())
+    return (value if value.is_absolute() else root / value).resolve()
+
+
+def repo_identity(root: Path) -> dict[str, str]:
+    resolved_root = root.resolve()
+    common_dir = git_common_dir(resolved_root)
+    material = "\0".join((str(resolved_root), str(common_dir)))
+    return {
+        "repo_id": hashlib.sha256(material.encode("utf-8")).hexdigest()[:12],
+        "repo_root": str(resolved_root),
+        "git_common_dir": str(common_dir),
+        "state_dir": str(resolved_root / STATE_DIR),
+    }
+
+
+def state_dir(root: Path) -> Path:
+    path = root / STATE_DIR
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def read_json(path: Path, default: object) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def read_file(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def policy(root: Path) -> dict[str, object]:
+    merged = dict(DEFAULT_POLICY)
+    loaded = read_json(root / POLICY_FILE, {})
+    if isinstance(loaded, dict):
+        merged.update(loaded)
+    return merged
+
+
+def active_path(root: Path) -> Path:
+    return state_dir(root) / "active.json"
+
+
+def active_state(root: Path) -> dict[str, object]:
+    loaded = read_json(active_path(root), {})
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def contract_path(root: Path) -> Path:
+    return state_dir(root) / "contract.json"
+
+
+def events_path(root: Path) -> Path:
+    return state_dir(root) / "events.jsonl"
+
+
+def contract(root: Path) -> dict[str, object]:
+    loaded = read_json(contract_path(root), {})
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def log_event(root: Path, event: dict[str, object]) -> None:
+    item = {"time": time.time(), **event}
+    with events_path(root).open("a", encoding="utf-8") as file:
+        file.write(json.dumps(item, sort_keys=True) + "\n")
+
+
+def events(root: Path, limit: int = 200) -> list[dict[str, object]]:
+    path = events_path(root)
+    if not path.exists():
+        return []
+    out: list[dict[str, object]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines()[-limit:]:
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            out.append(value)
+    return out
+
+
+def hook_input() -> dict[str, object]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def emit(value: dict[str, object]) -> None:
+    print(json.dumps(value, separators=(",", ":")))
+
+
+def deny(event: str, reason: str) -> None:
+    if event == "PreToolUse":
+        emit(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                },
+                "decision": "block",
+                "reason": reason,
+            }
+        )
+    elif event == "PermissionRequest":
+        emit(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {"behavior": "deny", "message": reason},
+                }
+            }
+        )
+    else:
+        emit({"decision": "block", "reason": reason})
+
+
+def command_hint(root: Path | None = None) -> str:
+    script = os.environ.get("LEAN_CODE_GATE_SCRIPT_PATH") or ".agent/lean/lean_code_gate.py"
+    command = f"PYTHONDONTWRITEBYTECODE=1 python3 -B -S {shlex.quote(script)}"
+    if root is not None and os.environ.get("LEAN_CODE_GATE_REPO_ROOT"):
+        return f"LEAN_CODE_GATE_REPO_ROOT={shlex.quote(str(root))} {command}"
+    return command
+
+
+def context(event: str) -> None:
+    message = (
+        "Lean Code Gate v3 active. Inspect first, then declare the smallest Lean Change Contract before mutating files. "
+        f"Micro-fix form: `{command_hint()} declare "
+        "--minimal-preflight --intent \"...\" --scope \"file1,file2\" --task-type bugfix --verify \"pytest path/to/test.py\"`. "
+        "Full production form adds --affected-surface, --authoritative-contract, --invariant, --reuse-path or --no-reuse-reason, "
+        "--proof-plan, and --risk-check. Stop runs the quality gate: no fake-green suppressions, duplicate blocks, "
+        "high-confidence helper reimplementation, temp artifacts, or bloat."
+    )
+    emit({"hookSpecificOutput": {"hookEventName": event, "additionalContext": message}})
+
+
+def norm_path(value: str) -> str:
+    return value.strip().replace(os.sep, "/").removeprefix("./")
+
+
+def norm_list(csv: str | None) -> list[str]:
+    return [norm_path(item) for item in (csv or "").split(",") if item.strip()]
+
+
+def rel(root: Path, raw: str) -> str | None:
+    if not raw:
+        return None
+    value = raw.strip().strip("'\"")
+    if value in {"/dev/null", "dev/null"}:
+        return None
+    if value.startswith(("a/", "b/")):
+        value = value[2:]
+    try:
+        path = Path(value)
+        resolved = (path if path.is_absolute() else root / path).resolve()
+        return resolved.relative_to(root).as_posix()
+    except Exception:
+        return None
+
+
+def match(path: str, globs: list[str]) -> bool:
+    return any(path == glob or fnmatch.fnmatch(path, glob) or ("/" not in glob and Path(path).name == glob) for glob in globs)
+
+
+def internal_gate_path(path: str) -> bool:
+    normalized = norm_path(path)
+    return (
+        normalized == STATE_DIR
+        or normalized.startswith(STATE_DIR + "/")
+        or normalized == ".agent/lean/__pycache__"
+        or normalized.startswith(".agent/lean/__pycache__/")
+        or (normalized.startswith(".agent/lean/") and normalized.endswith(".pyc"))
+    )
+
+
+def run_git(repo: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return run_process(["git", "-c", "gc.auto=0", "-c", "maintenance.auto=false", *args], repo, timeout=15)
+
+
+def git_text(repo: Path, args: list[str]) -> str:
+    result = run_git(repo, args)
+    return result.stdout if result.returncode == 0 else ""
+
+
+def git_ok(repo: Path, args: list[str]) -> bool:
+    return run_git(repo, args).returncode == 0
+
+
+def read_git_file(repo: Path, ref: str, rel_path: str) -> str | None:
+    if not ref:
+        return None
+    result = run_git(repo, ["show", f"{ref}:{rel_path}"])
+    return result.stdout if result.returncode == 0 else None
+
+
+def parse_name_status(raw: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in raw.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            out[norm_path(parts[-1])] = parts[0]
+    return out
+
+
+def parse_status_paths(raw: str) -> tuple[dict[str, str], set[str]]:
+    changed: dict[str, str] = {}
+    untracked: set[str] = set()
+    records = [item for item in raw.split("\0") if item]
+    index = 0
+    while index < len(records):
+        record = records[index]
+        if len(record) < 4:
+            index += 1
+            continue
+        xy = record[:2]
+        path = norm_path(record[3:])
+        changed[path] = xy
+        if xy == "??":
+            untracked.add(path)
+        if xy[0] in {"R", "C"} and index + 1 < len(records):
+            changed[norm_path(records[index + 1])] = xy
+            index += 1
+        index += 1
+    return changed, untracked
+
+
+def parse_numstat(raw: str) -> list[Numstat]:
+    records: list[Numstat] = []
+    for line in raw.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        try:
+            added = int(parts[0])
+            deleted = int(parts[1])
+        except ValueError:
+            added = 10000
+            deleted = 10000
+        records.append(Numstat(added=added, deleted=deleted, path=norm_path("\t".join(parts[2:]))))
+    return records
+
+
+def parse_name_only(raw: str) -> set[str]:
+    return {norm_path(line) for line in raw.splitlines() if norm_path(line)}
+
+
+def added_file_paths(root: Path) -> set[str]:
+    status, untracked = parse_status_paths(git_text(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]))
+    added = set(untracked)
+    for path, state in status.items():
+        if internal_gate_path(path):
+            continue
+        if state == "??" or "A" in state or "C" in state:
+            added.add(path)
+    return {path for path in added if not internal_gate_path(path)}
+
+
+def merge_numstats(records: Iterable[Numstat]) -> dict[str, Numstat]:
+    merged: dict[str, Numstat] = {}
+    for record in records:
+        previous = merged.get(record.path)
+        if previous is None:
+            merged[record.path] = record
+        else:
+            merged[record.path] = Numstat(previous.added + record.added, previous.deleted + record.deleted, record.path)
+    return merged
+
+
+def status_snapshot(root: Path) -> dict[str, object]:
+    status, untracked = parse_status_paths(git_text(root, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]))
+    status = {path: state for path, state in status.items() if not internal_gate_path(path)}
+    untracked = {path for path in untracked if not internal_gate_path(path)}
+    numstats = merge_numstats(record for record in parse_numstat(git_text(root, ["diff", "HEAD", "--numstat"])) if not internal_gate_path(record.path))
+    untracked_lines = {}
+    for path in untracked:
+        text = read_file(root / path)
+        if text is not None:
+            untracked_lines[path] = len(text.splitlines())
+    return {
+        "status": status,
+        "numstat": {path: [stat.added, stat.deleted] for path, stat in numstats.items()},
+        "untrackedLines": untracked_lines,
+        "at": time.time(),
+    }
+
+
+def baseline(root: Path) -> dict[str, object]:
+    return status_snapshot(root)
+
+
+def delta(root: Path, current_contract: dict[str, object]) -> dict[str, object]:
+    base = current_contract.get("baseline") or {}
+    now = status_snapshot(root)
+    base_status = base.get("status") if isinstance(base.get("status"), dict) else {}
+    base_numstat = base.get("numstat") if isinstance(base.get("numstat"), dict) else {}
+    base_untracked = base.get("untrackedLines") if isinstance(base.get("untrackedLines"), dict) else {}
+    now_status = now.get("status") if isinstance(now.get("status"), dict) else {}
+    now_numstat = now.get("numstat") if isinstance(now.get("numstat"), dict) else {}
+    now_untracked = now.get("untrackedLines") if isinstance(now.get("untrackedLines"), dict) else {}
+
+    files: set[str] = set()
+    for path, value in now_status.items():
+        if value != base_status.get(path):
+            files.add(path)
+    for path, value in now_numstat.items():
+        if list(value) != list(base_numstat.get(path, [])):
+            files.add(path)
+    for path, value in now_untracked.items():
+        if int(value) != int(base_untracked.get(path, -1)):
+            files.add(path)
+
+    added = 0
+    deleted = 0
+    for path in files:
+        current_added, current_deleted = _numstat_pair(now_numstat.get(path))
+        base_added, base_deleted = _numstat_pair(base_numstat.get(path))
+        added += max(0, current_added - base_added)
+        deleted += max(0, current_deleted - base_deleted)
+        if path in now_untracked and path not in base_untracked:
+            added += int(now_untracked.get(path) or 0)
+    return {"files": sorted(files), "added": added, "deleted": deleted, "changed": added + deleted}
+
+
+def _numstat_pair(value: object) -> tuple[int, int]:
+    if isinstance(value, (list, tuple)) and len(value) >= 2:
+        return int(value[0] or 0), int(value[1] or 0)
+    return 0, 0
+
+
+def collect_added_lines(raw_diff: str) -> dict[str, list[tuple[int, str]]]:
+    added: dict[str, list[tuple[int, str]]] = {}
+    current = ""
+    new_line = 0
+    for line in raw_diff.splitlines():
+        if line.startswith("diff --git "):
+            current = ""
+            new_line = 0
+            continue
+        if line.startswith("+++ b/"):
+            current = norm_path(line[len("+++ b/") :])
+            continue
+        if line.startswith("@@ "):
+            found = re.search(r"\+(\d+)(?:,\d+)?", line)
+            new_line = int(found.group(1)) if found else 0
+            continue
+        if not current or not new_line:
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            added.setdefault(current, []).append((new_line, line[1:]))
+            new_line += 1
+        elif line.startswith(" ") and not line.startswith("+++"):
+            new_line += 1
+    return added
+
+
+def collect_scope(repo: Path, base_ref: str | None) -> GateContext:
+    status_changed, untracked = parse_status_paths(git_text(repo, ["status", "--porcelain=v1", "-z", "--untracked-files=all"]))
+    changed = {path for path in status_changed if not internal_gate_path(path)}
+    raw_diffs: list[str] = []
+    numstats: list[Numstat] = []
+    base_for_file = "HEAD"
+
+    if base_ref:
+        if git_ok(repo, ["rev-parse", "--verify", base_ref]):
+            changed |= parse_name_only(git_text(repo, ["diff", "--name-only", f"{base_ref}...HEAD"]))
+            for args in (
+                ["diff", "--unified=0", "--no-color", f"{base_ref}...HEAD"],
+                ["diff", "--cached", "--unified=0", "--no-color"],
+                ["diff", "--unified=0", "--no-color"],
+            ):
+                raw_diffs.append(git_text(repo, args))
+            for args in (
+                ["diff", "--numstat", f"{base_ref}...HEAD"],
+                ["diff", "--cached", "--numstat"],
+                ["diff", "--numstat"],
+            ):
+                numstats.extend(parse_numstat(git_text(repo, args)))
+            base_for_file = base_ref
+    else:
+        raw_diffs.append(git_text(repo, ["diff", "HEAD", "--unified=0", "--no-color"]))
+        numstats.extend(parse_numstat(git_text(repo, ["diff", "HEAD", "--numstat"])))
+        if not changed and git_ok(repo, ["rev-parse", "--verify", "HEAD~1"]):
+            changed = parse_name_only(git_text(repo, ["diff", "--name-only", "HEAD~1..HEAD"]))
+            raw_diffs = [git_text(repo, ["diff", "--unified=0", "--no-color", "HEAD~1..HEAD"])]
+            numstats = parse_numstat(git_text(repo, ["diff", "--numstat", "HEAD~1..HEAD"]))
+            base_for_file = "HEAD~1"
+    changed |= {path for path in untracked if not internal_gate_path(path)}
+    changed = {path for path in changed if not internal_gate_path(path)}
+    untracked = {path for path in untracked if not internal_gate_path(path)}
+    numstats = [record for record in numstats if not internal_gate_path(record.path)]
+    raw_diff = "\n".join(part for part in raw_diffs if part)
+    return GateContext(repo, changed, untracked, raw_diff, base_for_file, numstats, collect_added_lines(raw_diff))
+
+
+def parse_patch(root: Path, text: str) -> dict[str, object]:
+    paths: set[str] = set()
+    added = 0
+    deleted = 0
+    add_text: list[str] = []
+    add_file = False
+    delete_file = False
+    for line in text.splitlines():
+        if line.startswith(("*** Update File:", "*** Add File:", "*** Delete File:")):
+            path = rel(root, line.split(":", 1)[1].strip())
+            if path:
+                paths.add(path)
+            add_file = add_file or line.startswith("*** Add File:")
+            delete_file = delete_file or line.startswith("*** Delete File:")
+        elif line.startswith("diff --git "):
+            parts = line.split()
+            if len(parts) >= 4:
+                path = rel(root, parts[3])
+                if path:
+                    paths.add(path)
+        elif line.startswith(("+++ ", "--- ")):
+            bits = line.split(maxsplit=1)
+            if len(bits) == 2:
+                path = rel(root, bits[1])
+                if path:
+                    paths.add(path)
+        elif line.startswith("+") and not line.startswith("+++"):
+            added += 1
+            add_text.append(line[1:])
+        elif line.startswith("-") and not line.startswith("---"):
+            deleted += 1
+    return {"paths": sorted(paths), "added": added, "deleted": deleted, "text": "\n".join(add_text), "add_file": add_file, "delete_file": delete_file, "patch_like": True}
+
+
+def facts(root: Path, tool: str, tool_input: dict[str, object]) -> dict[str, object]:
+    if tool in {"apply_patch", "ApplyPatch"}:
+        return parse_patch(root, str(tool_input.get("command") or tool_input.get("patch") or ""))
+    if tool == "Bash":
+        command = tool_command(tool_input)
+        if "apply_patch" in command or "*** Begin Patch" in command or "diff --git" in command:
+            return parse_patch(root, command)
+        return {"paths": [], "added": 0, "deleted": 0, "text": "", "add_file": False, "delete_file": False, "patch_like": False}
+    if tool == "Write":
+        path = rel(root, str(tool_input.get("file_path") or tool_input.get("path") or ""))
+        text = str(tool_input.get("content") or "")
+        return {"paths": [path] if path else [], "added": len(text.splitlines()), "deleted": 0, "text": text, "add_file": bool(path and not (root / path).exists()), "delete_file": False, "patch_like": False}
+    if tool in {"Edit", "MultiEdit", "NotebookEdit"}:
+        path = rel(root, str(tool_input.get("file_path") or tool_input.get("path") or ""))
+        edits = tool_input.get("edits") if tool == "MultiEdit" else [tool_input]
+        added = 0
+        deleted = 0
+        chunks: list[str] = []
+        for edit in edits or []:
+            if not isinstance(edit, dict):
+                continue
+            new = str(edit.get("new_string") or "")
+            old = str(edit.get("old_string") or "")
+            new_lines = len(new.splitlines())
+            old_lines = len(old.splitlines())
+            # Count replacement text as touched content, not just net growth.
+            # Otherwise a 400-line rewrite with the same line count looks like zero work.
+            added += new_lines
+            deleted += old_lines
+            chunks.append(new)
+        return {"paths": [path] if path else [], "added": added, "deleted": deleted, "text": "\n".join(chunks), "add_file": False, "delete_file": False, "patch_like": False}
+    return {"paths": [], "added": 0, "deleted": 0, "text": "", "add_file": False, "delete_file": False, "patch_like": False}
+
+
+def guard_command(command: str) -> bool:
+    return "lean_code_gate.py" in command and re.search(r"\b(declare|status|reset|check)\b", command) is not None
+
+
+def mutating(tool: str, tool_input: dict[str, object]) -> bool:
+    if tool in MUTATING_TOOLS:
+        return True
+    command = tool_command(tool_input)
+    return tool == "Bash" and not guard_command(command) and not ("apply_patch" in command or "*** Begin Patch" in command or "diff --git" in command) and bool(HIDDEN_WRITE_RE.search(command))
+
+
+def verify_cmd(command: str) -> bool:
+    value = re.sub(r"\s+", " ", command.strip().lower())
+    return any(hint in value for hint in VERIFY_HINTS)
+
+
+def response_exit_code(value: object) -> int | None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            lowered = str(key).lower().replace("-", "_")
+            if lowered in {"exit_code", "exitcode", "returncode", "return_code", "status_code"}:
+                try:
+                    return int(item)
+                except (TypeError, ValueError):
+                    pass
+        for item in value.values():
+            found = response_exit_code(item)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for item in value:
+            found = response_exit_code(item)
+            if found is not None:
+                return found
+    elif isinstance(value, str):
+        found = re.search(r"\b(?:exit code|exit_code|returncode|return code|status)\D+(-?\d+)\b", value, re.I)
+        if found:
+            return int(found.group(1))
+    return None
+
+
+def path_type(path: str) -> str:
+    if Path(path).name in DEPENDENCY_FILES:
+        return "dependency"
+    if match(path, CONFIG_GLOBS):
+        return "config"
+    if match(path, TEST_GLOBS):
+        return "test"
+    return "prod"
+
+
+def design_hits(text: str) -> list[str]:
+    return [name for pattern, name in DESIGN_RE if pattern.search(text)]
+
+
+def is_binary_path(path: str) -> bool:
+    return Path(path).suffix.lower() in BINARY_EXTENSIONS
+
+
+_active_excluded_globs: tuple[str, ...] = ()
+_active_framework_override_names: frozenset[str] = frozenset()
+_active_suppress_private_public_siblings: bool = False
+_active_min_duplicate_count: int = 2
+
+
+def is_excluded_path(path: str) -> bool:
+    parts = [part.lower() for part in norm_path(path).split("/") if part]
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return True
+    lowered = f"/{norm_path(path).lower()}"
+    if any(marker in lowered for marker in ("/.codex/quality/logs/", "/.agent/lean/", "/logs/")):
+        return True
+    if not _active_excluded_globs:
+        return False
+    normalized = norm_path(path).lower()
+    # fnmatch treats ** as a single * (no multi-segment semantics). To match
+    # globs like "**/migrations/**" against first-component paths like
+    # "migrations/0001.py", check both the bare path and a /-prefixed variant.
+    candidates = (normalized, "/" + normalized)
+    return any(
+        fnmatch.fnmatch(c, glob.lower()) for glob in _active_excluded_globs for c in candidates
+    )
+
+
+def is_test_like_path(path: str) -> bool:
+    lowered = f"/{norm_path(path).lower()}"
+    if any(marker in lowered for marker in TEST_MARKERS):
+        return True
+    name = Path(path).name.lower()
+    return bool(re.search(r"\.(?:test|spec)\.", name)) or name.endswith(".schema.json")
+
+
+def is_source_path(path: str) -> bool:
+    return bool(path) and not is_excluded_path(path) and not is_binary_path(path) and Path(path).suffix.lower() in SOURCE_EXTENSIONS
+
+
+def is_production_source_path(path: str) -> bool:
+    return is_source_path(path) and not is_test_like_path(path)
+
+
+def language_for_path(path: str) -> str:
+    suffix = Path(path).suffix.lower()
+    if suffix == ".py":
+        return "python"
+    if suffix in {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"}:
+        return "javascript"
+    return {".go": "go", ".rs": "rust", ".sh": "shell", ".php": "php", ".rb": "ruby"}.get(suffix, suffix.lstrip(".") or "source")
+
+
+def is_temp_artifact(path: str) -> bool:
+    lowered = norm_path(path).lower()
+    if not lowered:
+        return False
+    return bool(re.search(r"(^|/)(?:\.tmp|tmp|temp)(/|$)", lowered)) or lowered.endswith((".bak", ".orig", ".rej", ".tmp"))
+
+
+def physical_lines(text: str | None) -> int:
+    return len(text.splitlines()) if text else 0
+
+
+def rules_for_path(path: str) -> list[re.Pattern[str]]:
+    suffix = Path(path).suffix.lower()
+    rules = list(GENERAL_ESCAPE_RULES)
+    if suffix == ".py" and is_production_source_path(path):
+        rules.extend(PYTHON_ESCAPE_RULES)
+    if suffix in {".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"} and is_production_source_path(path):
+        rules.extend(TS_ESCAPE_RULES)
+    return rules
+
+
+def line_hits(path: str, lines: list[tuple[int, str]], rules: list[re.Pattern[str]]) -> list[str]:
+    hits = []
+    for line_no, text in lines:
+        if any(rule.search(text) for rule in rules):
+            hits.append(f"{path}:{line_no}")
+    return hits
+
+
+def multiline_hits(path: str, text: str) -> list[str]:
+    return [f"{path}:{text[: match.start()].count(chr(10)) + 1}" for rule in EMPTY_CATCH_RULES for match in rule.finditer(text)]
+
+def advisory_finding(rule: str, family: str, path: str, line: int, severity: str, message: str, evidence: str) -> dict[str, object]:
+    return {
+        "rule": rule,
+        "family": family,
+        "path": path,
+        "line": line,
+        "severity": severity,
+        "message": message,
+        "evidence": evidence,
+    }
+
+
+def first_rule_match(text: str, rules: list[tuple[re.Pattern[str], str]]) -> str:
+    return next((label for pattern, label in rules if pattern.search(text)), "")
+
+
+def scan_sensitive_input(ctx: GateContext) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items():
+        if is_production_source_path(rel_path):
+            findings.extend(scan_sensitive_input_lines(rel_path, lines))
+    return findings
+
+
+def scan_sensitive_input_lines(path: str, lines: list[tuple[int, str]]) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    sinks = [(line_no, text, first_rule_match(text, SENSITIVE_SINK_RULES)) for line_no, text in lines]
+    for line_no, text in lines:
+        source = first_rule_match(text, SENSITIVE_SOURCE_RULES)
+        if not source:
+            continue
+        sink = sensitive_sink_for_source(line_no, text, sinks)
+        severity = "high" if sink else "warning"
+        evidence = f"source={source}" + (f"; sink={sink}" if sink else "")
+        message = "added code reads sensitive input" + (" and exposes or persists it nearby" if sink else "; keep it out of logs, persistence, and telemetry")
+        findings.append(advisory_finding("sensitive-input", "security", path, line_no, severity, message, evidence))
+    return findings
+
+
+def sensitive_sink_for_source(line_no: int, text: str, sinks: list[tuple[int, str, str]]) -> str:
+    same_line = first_rule_match(text, SENSITIVE_SINK_RULES)
+    if same_line:
+        return same_line
+    identifier = assigned_identifier(text)
+    if not identifier:
+        return ""
+    use_re = re.compile(rf"\b{re.escape(identifier)}\b")
+    return next((label for sink_line, sink_text, label in sinks if label and 0 < sink_line - line_no <= 8 and use_re.search(sink_text)), "")
+
+
+def assigned_identifier(text: str) -> str:
+    found = SENSITIVE_IDENTIFIER_RE.search(text)
+    return found.group(1) if found else ""
+
+
+
+
+def scan_quality_escapes(ctx: GateContext) -> list[str]:
+    # Path filter is is_source_path (not is_production_source_path) by design.
+    # Reuse/duplicate/bloat detectors filter to is_production_source_path
+    # because their findings are scoped to the new code's relationship to
+    # the production codebase. Quality-escape's path filter is broader so
+    # GENERAL_ESCAPE_RULES (TODO/FIXME, # type: ignore, @ts-ignore,
+    # eslint-disable, # noqa, || true) catches escapes in test/fixture
+    # paths too — those locations are particularly prone to vestigial
+    # suppressions (Wen et al. FSE 2025: 50.8% of suppressions are useless).
+    # Language-typed rules (PYTHON_ESCAPE_RULES, TS_ESCAPE_RULES — `: Any`,
+    # `as any`, bare `except:`) DO restrict to production via
+    # is_production_source_path inside rules_for_path; mocks in tests
+    # legitimately use `as any` and shouldn't trip this layer.
+    hits: list[str] = []
+    for rel_path, lines in ctx.added_lines.items():
+        if is_source_path(rel_path):
+            hits.extend(line_hits(rel_path, lines, rules_for_path(rel_path)))
+    for rel_path in sorted(ctx.untracked):
+        if not is_source_path(rel_path):
+            continue
+        text = read_file(ctx.repo / rel_path)
+        if text is None:
+            continue
+        hits.extend(line_hits(rel_path, list(enumerate(text.splitlines(), 1)), rules_for_path(rel_path)))
+        hits.extend(multiline_hits(rel_path, text))
+    hits.extend(multiline_added_hits(ctx.added_lines))
+    return sorted(set(hits))
+
+
+def multiline_added_hits(added_by_file: dict[str, list[tuple[int, str]]]) -> list[str]:
+    hits: list[str] = []
+    for path, values in added_by_file.items():
+        joined = "\n".join(text for _, text in values)
+        for rule in EMPTY_CATCH_RULES:
+            for match_obj in rule.finditer(joined):
+                line_offset = joined[: match_obj.start()].count("\n")
+                line_no = values[min(line_offset, len(values) - 1)][0] if values else 1
+                hits.append(f"{path}:{line_no}")
+    return hits
+
+
+def duplicate_added_blocks(ctx: GateContext) -> list[dict[str, object]]:
+    return _duplicate_added_blocks_at_count(ctx, _active_min_duplicate_count)
+
+
+def duplicate_added_blocks_all(ctx: GateContext) -> list[dict[str, object]]:
+    """All raw duplicate windows (count>=2), no threshold filter. For telemetry."""
+    return _duplicate_added_blocks_at_count(ctx, 2)
+
+
+def _duplicate_added_blocks_at_count(ctx: GateContext, min_count: int) -> list[dict[str, object]]:
+    windows: dict[str, dict[str, object]] = {}
+    added_by_file = ctx.added_lines_with_untracked(production_only=True)
+    for rel_path, lines in added_by_file.items():
+        if not is_production_source_path(rel_path):
+            continue
+        normalized = duplicate_candidate_lines(lines)
+        for index in range(0, max(0, len(normalized) - 2)):
+            key = duplicate_window_key(normalized, index)
+            if len(key) < 80:
+                continue
+            item = windows.setdefault(key, {"count": 0, "files": set(), "sample": key[:180]})
+            item["count"] = int(item["count"]) + 1
+            files = item["files"]
+            if isinstance(files, set):
+                files.add(rel_path)
+    return collapse_duplicate_findings(
+        [
+            {"count": item["count"], "files": sorted(item["files"]), "sample": item["sample"]}
+            for item in windows.values()
+            if int(item["count"]) >= min_count and isinstance(item["files"], set)
+        ]
+    )
+
+
+def duplicate_candidate_lines(lines: list[tuple[int, str]]) -> list[str]:
+    normalized = [
+        re.sub(r"\s+", " ", text.strip()).rstrip(";,")
+        for _, text in lines
+        if text.strip() and not text.strip().startswith(("//", "#", "*"))
+    ]
+    return [
+        line
+        for line in normalized
+        if line not in {"{", "}"} and not re.match(r"^(?:export\s+)?(?:async\s+)?function\s+\w+\(", line)
+    ]
+
+
+def duplicate_window_key(lines: list[str], index: int) -> str:
+    chunk = lines[index : index + 3]
+    if index and lines[index - 1] == lines[index]:
+        return ""
+    if index + 3 < len(lines) and lines[index + 2] == lines[index + 3]:
+        return ""
+    if any("wait_for_timeout" in line for line in chunk) and index >= 2:
+        chunk = lines[max(0, index - 2) : index + 3]
+    return " | ".join(chunk)
+
+
+def collapse_duplicate_findings(items: list[dict[str, object]]) -> list[dict[str, object]]:
+    collapsed: list[dict[str, object]] = []
+    for item in sorted(items, key=lambda value: (str(value["files"]), str(value["sample"]))):
+        duplicate = next((existing for existing in collapsed if same_duplicate_family(existing, item)), None)
+        if duplicate is None:
+            collapsed.append(item)
+        else:
+            duplicate["count"] = int(duplicate["count"]) + int(item["count"])
+    return collapsed
+
+
+def same_duplicate_family(left: dict[str, object], right: dict[str, object]) -> bool:
+    if left["files"] != right["files"]:
+        return False
+    left_tokens = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]+", str(left["sample"])))
+    right_tokens = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]+", str(right["sample"])))
+    if not left_tokens or not right_tokens:
+        return False
+    return len(left_tokens & right_tokens) / min(len(left_tokens), len(right_tokens)) >= 0.6
+
+
+def evaluate_bloat(ctx: GateContext, active_policy: dict[str, object]) -> tuple[list[str], list[str], dict[str, object]]:
+    errors: list[str] = []
+    warnings: list[str] = []
+    details, total_added, total_deleted, shrink_by_dir = bloat_file_details(ctx)
+    for detail in details:
+        errors.extend(bloat_errors_for_file(detail, shrink_by_dir, active_policy))
+        warnings.extend(bloat_warnings_for_file(detail, active_policy))
+    if total_added >= int(active_policy["bloat_total_added_error_lines"]) and total_added > max(1, total_deleted) * int(active_policy["bloat_add_delete_error_ratio"]):
+        errors.append(f"changed source diff is heavily additive: added={total_added} deleted={total_deleted}")
+    elif total_added >= int(active_policy["bloat_total_added_warn_lines"]) and total_added > max(1, total_deleted) * int(active_policy["bloat_add_delete_warn_ratio"]):
+        warnings.append(f"changed source diff is additive: added={total_added} deleted={total_deleted}")
+    return errors, warnings, {"totalAdded": total_added, "totalDeleted": total_deleted, "files": details[:50]}
+
+
+def bloat_file_details(ctx: GateContext) -> tuple[list[dict[str, object]], int, int, dict[str, int]]:
+    numstat = merge_numstats(ctx.numstats)
+    details: list[dict[str, object]] = []
+    total_added = 0
+    total_deleted = 0
+    shrink_by_dir: dict[str, int] = {}
+    for rel_path in sorted(ctx.changed_files):
+        if not is_production_source_path(rel_path):
+            continue
+        current_text = read_file(ctx.repo / rel_path)
+        if current_text is None:
+            continue
+        base_text = read_git_file(ctx.repo, ctx.base_for_file, rel_path)
+        baseline_lines = physical_lines(base_text) if base_text is not None else None
+        current_lines = physical_lines(current_text)
+        record = numstat.get(rel_path)
+        added = record.added if record else (current_lines if baseline_lines is None else 0)
+        deleted = record.deleted if record else 0
+        total_added += added
+        total_deleted += deleted
+        parent = str(Path(rel_path).parent).replace(os.sep, "/")
+        if deleted > added:
+            shrink_by_dir[parent] = shrink_by_dir.get(parent, 0) + deleted - added
+        details.append(
+            {
+                "file": rel_path,
+                "added": added,
+                "deleted": deleted,
+                "currentLines": current_lines,
+                "baselineLines": baseline_lines,
+                "netGrowth": max(0, added - deleted),
+            }
+        )
+    return details, total_added, total_deleted, shrink_by_dir
+
+
+def bloat_errors_for_file(detail: dict[str, object], shrink_by_dir: dict[str, int], active_policy: dict[str, object]) -> list[str]:
+    rel_path = str(detail["file"])
+    current_lines = int(detail["currentLines"])
+    baseline_lines = detail["baselineLines"]
+    net_growth = int(detail["netGrowth"])
+    available_shrink = shrink_by_dir.get(str(Path(rel_path).parent).replace(os.sep, "/"), 0)
+    if baseline_lines is None:
+        threshold = int(active_policy["bloat_new_file_error_lines"])
+        return [f"new source file {rel_path} has {current_lines} lines (>{threshold})"] if current_lines > threshold else []
+    baseline_value = int(baseline_lines)
+    large_file = baseline_value > int(active_policy["bloat_large_file_lines"])
+    if large_file and bool(active_policy.get("bloat_large_file_must_shrink")) and current_lines >= baseline_value:
+        return [f"large source file {rel_path} must shrink when touched ({current_lines} >= {baseline_value})"]
+    if net_growth > int(active_policy["bloat_file_growth_lines"]) and available_shrink < net_growth:
+        return [f"source file {rel_path} grew by {net_growth} lines without same-directory shrink"]
+    if large_file and net_growth > int(active_policy["bloat_large_file_growth_lines"]) and available_shrink < net_growth:
+        return [f"large source file {rel_path} grew by {net_growth} lines without same-directory shrink"]
+    return []
+
+
+def bloat_warnings_for_file(detail: dict[str, object], active_policy: dict[str, object]) -> list[str]:
+    threshold = int(active_policy["bloat_new_file_warn_lines"])
+    if detail["baselineLines"] is None and int(detail["currentLines"]) > threshold:
+        return [f"new source file {detail['file']} has {detail['currentLines']} lines (>{threshold})"]
+    baseline_lines = detail["baselineLines"]
+    net_growth = int(detail["netGrowth"])
+    if baseline_lines is not None and int(baseline_lines) > int(active_policy["bloat_large_file_lines"]) and net_growth > 0:
+        return [f"large source file {detail['file']} grew by {net_growth} lines"]
+    return []
+
+
+def split_name_tokens(name: str) -> tuple[str, ...]:
+    expanded = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", name)
+    expanded = re.sub(r"[^A-Za-z0-9]+", " ", expanded)
+    tokens = tuple(token.lower() for token in expanded.split() if len(token) > 1)
+    return tokens or (name.lower(),)
+
+
+def extract_symbols(path: str, text: str, source: str, context_boost: int = 0) -> list[SymbolDef]:
+    language = language_for_path(path)
+    symbols: list[SymbolDef] = []
+    for line_no, line in enumerate(text.splitlines(), 1):
+        for kind, pattern in SYMBOL_PATTERNS.get(language, []):
+            found = pattern.search(line)
+            if found:
+                name = found.group(1)
+                symbols.append(SymbolDef(name, path, line_no, kind, language, split_name_tokens(name), source, context_boost))
+                break
+    return symbols
+
+
+def subtree_score(path_a: str, path_b: str) -> int:
+    parts_a = norm_path(path_a).split("/")[:-1]
+    parts_b = norm_path(path_b).split("/")[:-1]
+    if not parts_a or not parts_b:
+        return 0
+    if parts_a == parts_b:
+        return 10
+    shared = 0
+    for left, right in zip(parts_a, parts_b):
+        if left != right:
+            break
+        shared += 1
+    return 10 if shared >= 2 else 5 if shared == 1 else 0
+
+
+def token_overlap(left: tuple[str, ...], right: tuple[str, ...]) -> float:
+    left_set = set(left)
+    right_set = set(right)
+    return len(left_set & right_set) / max(len(left_set), len(right_set)) if left_set and right_set else 0.0
+
+
+def same_behavior_name(left: SymbolDef, right: SymbolDef) -> tuple[int, str]:
+    if _active_framework_override_names and left.name in _active_framework_override_names and right.name in _active_framework_override_names:
+        return 0, ""
+    # R-3 (private/public sibling): suppress at the candidate-evaluation
+    # stage. Structural blind spot — caller's `if base_score <= 0: continue`
+    # means body-similarity scoring is not reached for any _foo/foo pair,
+    # even genuine identical implementations. Calibrated tradeoff: prefer FN
+    # over FP given the observed FP rate in the 50-commit Django window.
+    if _active_suppress_private_public_siblings and left.tokens == right.tokens and left.tokens and left.name.strip("_") == right.name.strip("_") and left.name != right.name:
+        return 0, ""
+    if left.name == right.name:
+        return (35, "generic same symbol name") if left.name.lower() in GENERIC_SYMBOLS else (100, "same symbol name")
+    if left.tokens == right.tokens and left.tokens:
+        return (35, "generic matching name tokens") if set(left.tokens) <= GENERIC_SYMBOLS else (90, "same name tokens")
+    overlap = token_overlap(left.tokens, right.tokens)
+    if overlap < 0.66:
+        return 0, ""
+    shared = sorted(set(left.tokens) & set(right.tokens))
+    if set(shared) & REUSE_ACTION_TOKENS:
+        return 52, f"matching behavior tokens: {', '.join(shared)}"
+    return 45, f"matching name tokens: {', '.join(shared)}"
+
+
+def detect_reuse_issues(ctx: GateContext, active_policy: dict[str, object]) -> list[ReuseFinding]:
+    mode = str(active_policy.get("reuse_detector_mode") or "conservative").lower()
+    if mode == "off":
+        return []
+    candidates = new_symbols(ctx) + risky_added_blocks(ctx)
+    if not candidates:
+        return []
+    existing = existing_symbol_index(ctx, candidates, active_policy)
+    if not existing:
+        return []
+    findings = score_reuse_candidates(candidates, existing, ctx.added_lines, deleted_definition_names(ctx.raw_diff), active_policy)
+    return findings[:30]
+
+
+def existing_symbol_index(ctx: GateContext, candidates: list[SymbolDef], active_policy: dict[str, object]) -> list[SymbolDef]:
+    symbols: list[SymbolDef] = []
+    indexed = 0
+    tracked = [norm_path(line) for line in git_text(ctx.repo, ["ls-files"]).splitlines() if norm_path(line)]
+    candidate_languages = {item.language for item in candidates}
+    candidate_roots = {top_dir(item.path) for item in candidates}
+    max_files = int(active_policy["quality_max_index_files"])
+    max_bytes = int(active_policy["quality_max_index_file_bytes"])
+    max_symbols = int(active_policy["quality_max_index_symbols"])
+    for rel_path in tracked:
+        if indexed >= max_files or len(symbols) >= max_symbols:
+            break
+        if rel_path in ctx.untracked or not is_production_source_path(rel_path):
+            continue
+        if language_for_path(rel_path) not in candidate_languages or top_dir(rel_path) not in candidate_roots:
+            continue
+        text = read_git_file(ctx.repo, ctx.base_for_file, rel_path) if rel_path in ctx.changed_files else read_file(ctx.repo / rel_path)
+        if text is None or len(text.encode("utf-8", errors="ignore")) > max_bytes:
+            continue
+        indexed += 1
+        for symbol in extract_symbols(rel_path, text, "baseline"):
+            symbols.append(symbol)
+            if len(symbols) >= max_symbols:
+                break
+    return symbols
+
+
+def new_symbols(ctx: GateContext) -> list[SymbolDef]:
+    symbols: list[SymbolDef] = []
+    for rel_path, lines in ctx.added_lines.items():
+        if not is_production_source_path(rel_path):
+            continue
+        for line_no, text in lines:
+            for symbol in extract_symbols(rel_path, text, "added"):
+                symbols.append(SymbolDef(symbol.name, rel_path, line_no, symbol.kind, symbol.language, symbol.tokens, symbol.source))
+    for rel_path in sorted(ctx.untracked):
+        if is_production_source_path(rel_path):
+            text = read_file(ctx.repo / rel_path)
+            if text is not None:
+                symbols.extend(extract_symbols(rel_path, text, "untracked"))
+    return symbols
+
+
+def risky_added_blocks(ctx: GateContext) -> list[SymbolDef]:
+    blocks: list[SymbolDef] = []
+    for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items():
+        if not is_production_source_path(rel_path):
+            continue
+        for line_no, text in lines:
+            dedupe_shape = bool(re.search(r"\bseen\s*=\s*set\s*\(|\bnot\s+in\s+seen\b", text))
+            if not RISKY_BLOCK_RULE.search(text) and not dedupe_shape:
+                continue
+            tokens = [token for token in split_name_tokens(text) if token in REUSE_ACTION_TOKENS]
+            if dedupe_shape:
+                tokens.append("dedupe")
+            if dedupe_shape or len(set(tokens)) >= 2:
+                blocks.append(SymbolDef("+".join(tokens[:3]), rel_path, line_no, "block", language_for_path(rel_path), tuple(tokens[:3]), "added"))
+    return blocks
+
+
+def deleted_definition_names(raw_diff: str) -> set[str]:
+    deleted: set[str] = set()
+    current = ""
+    for line in raw_diff.splitlines():
+        if line.startswith("diff --git "):
+            current = ""
+        elif line.startswith("--- a/"):
+            current = norm_path(line[len("--- a/") :])
+        elif current and is_production_source_path(current) and line.startswith("-") and not line.startswith("---"):
+            deleted.update(symbol.name for symbol in extract_symbols(current, line[1:], "deleted"))
+    return deleted
+
+
+def score_reuse_candidates(candidates: list[SymbolDef], existing: list[SymbolDef], added_by_file: dict[str, list[tuple[int, str]]], moved_or_deleted: set[str], active_policy: dict[str, object]) -> list[ReuseFinding]:
+    findings: list[ReuseFinding] = []
+    for new_item in candidates:
+        if new_item.name in moved_or_deleted or new_item.name.lower() in moved_or_deleted:
+            continue
+        best = best_existing_match(new_item, existing, added_by_file)
+        if best is None:
+            continue
+        score, reason, existing_item = best
+        error_score = int(active_policy.get("reuse_error_score", 90))
+        warning_score = int(active_policy.get("reuse_warning_score", 45))
+        high_confidence = high_confidence_reuse(new_item, existing_item)
+        severity = "error" if high_confidence or score >= error_score else "warning" if score >= warning_score else ""
+        if severity == "warning" and not warning_is_actionable(new_item, existing_item):
+            continue
+        if severity:
+            findings.append(ReuseFinding(severity, score, new_item.name, new_item.path, new_item.line, existing_item.name, existing_item.path, existing_item.line, reason))
+    findings.sort(key=lambda item: (item.severity != "error", -item.score, item.new_file, item.new_line))
+    return findings
+
+
+def high_confidence_reuse(new_item: SymbolDef, existing_item: SymbolDef) -> bool:
+    if new_item.kind == "block":
+        return "dedupe" in set(new_item.tokens) and "dedupe" in set(existing_item.tokens) and same_reuse_neighborhood(new_item.path, existing_item.path, existing_item.context_boost)
+    # Defer to the calibrated suppression in same_behavior_name: when R-2
+    # (framework_override_names) or R-3 (private/public siblings) returns 0,
+    # the pair should not be promoted to high-confidence reuse either.
+    # In the production call path (score_reuse_candidates →
+    # best_existing_match), pairs with same_behavior_name == 0 are already
+    # filtered by the `if base_score <= 0: continue` guard, so this check
+    # is unreachable from there. Kept as defense-in-depth and to enforce
+    # the function's contract for direct callers (unit tests, future code).
+    if same_behavior_name(new_item, existing_item)[0] == 0:
+        return False
+    if new_item.name == existing_item.name and new_item.name.lower() not in GENERIC_SYMBOLS:
+        return True
+    return new_item.tokens == existing_item.tokens and bool(new_item.tokens) and not set(new_item.tokens) <= GENERIC_SYMBOLS
+
+
+def best_existing_match(new_item: SymbolDef, existing: list[SymbolDef], added_by_file: dict[str, list[tuple[int, str]]]) -> tuple[int, str, SymbolDef] | None:
+    best: tuple[int, str, SymbolDef] | None = None
+    for existing_item in existing:
+        if existing_item.path == new_item.path and existing_item.name == new_item.name:
+            continue
+        if existing_item.language != new_item.language and new_item.kind != "block":
+            continue
+        if symbol_is_called_nearby(existing_item.name, added_by_file.get(new_item.path, []), new_item.line, new_item.language):
+            continue
+        base_score, reason = same_behavior_name(new_item, existing_item)
+        if new_item.kind == "block":
+            overlap = token_overlap(new_item.tokens, existing_item.tokens)
+            if overlap < 0.5:
+                continue
+            base_score = 55 + int(overlap * 20)
+            reason = f"new loop/helper block overlaps existing behavior tokens: {', '.join(set(new_item.tokens) & set(existing_item.tokens))}"
+        if base_score <= 0:
+            continue
+        if new_item.kind == "block" and not same_reuse_neighborhood(new_item.path, existing_item.path, existing_item.context_boost):
+            continue
+        score = min(100, base_score + subtree_score(new_item.path, existing_item.path) + existing_item.context_boost)
+        if existing_item.context_boost and base_score >= 52:
+            score = min(100, score + 10)
+        if best is None or score > best[0]:
+            best = (score, reason, existing_item)
+    return best
+
+
+def line_defines_symbol(language: str, text: str, symbol: str) -> bool:
+    # SYMBOL_PATTERNS is the source of truth for what counts as a definition
+    # in each supported language. Reusing it here keeps the def-line filter
+    # in lockstep with extraction; adding a new language to SYMBOL_PATTERNS
+    # automatically extends this filter without a parallel regex table.
+    return any(
+        (found := pattern.search(text)) is not None and found.group(1) == symbol
+        for _, pattern in SYMBOL_PATTERNS.get(language, [])
+    )
+
+
+def symbol_is_called_nearby(symbol: str, lines: list[tuple[int, str]], new_line: int, language: str) -> bool:
+    # Skip lines that *define* the searched symbol so its own def isn't
+    # read as a call to itself. Lines that define a *different* symbol but
+    # call this one stay visible: `def wrap(x, fn=parse_html_payload()):`
+    # is wrap's def line and a real call site for parse_html_payload.
+    call_pattern = re.compile(rf"\b{re.escape(symbol)}\s*\(")
+    return any(
+        not line_defines_symbol(language, text, symbol)
+        and max(0, new_line - 8) <= line_no <= new_line + 20
+        and call_pattern.search(text)
+        for line_no, text in lines
+    )
+
+
+def warning_is_actionable(new_item: SymbolDef, existing_item: SymbolDef) -> bool:
+    shared = set(new_item.tokens) & set(existing_item.tokens)
+    discriminating = shared - GENERIC_MATCH_TOKENS
+    has_shared_action = bool(discriminating & REUSE_ACTION_TOKENS)
+    return has_shared_action and len(discriminating) >= 2 and same_reuse_neighborhood(new_item.path, existing_item.path, existing_item.context_boost)
+
+
+def same_reuse_neighborhood(path_a: str, path_b: str, context_boost: int) -> bool:
+    return context_boost > 0 or top_dir(path_a) == top_dir(path_b)
+
+
+def top_dir(path: str) -> str:
+    return norm_path(path).split("/", 1)[0]
+
+
+def changed_file_failures(repo: Path, changed_files: set[str]) -> tuple[list[str], list[str]]:
+    conflict_files: list[str] = []
+    temp_files: list[str] = []
+    for rel_path in sorted(changed_files):
+        if is_temp_artifact(rel_path) and (repo / rel_path).exists():
+            temp_files.append(rel_path)
+        text = read_file(repo / rel_path)
+        if text is not None and not is_binary_path(rel_path) and re.search(r"^<{7} |^={7}$|^>{7} ", text, re.M):
+            conflict_files.append(rel_path)
+    return conflict_files, temp_files
+
+
+def apply_active_policy(active_policy: dict[str, object]) -> None:
+    global _active_excluded_globs, _active_framework_override_names, _active_suppress_private_public_siblings, _active_min_duplicate_count
+    raw_globs = active_policy.get("excluded_path_globs")
+    _active_excluded_globs = tuple(g for g in raw_globs if isinstance(g, str)) if isinstance(raw_globs, list) else ()
+    raw_names = active_policy.get("framework_override_names")
+    _active_framework_override_names = frozenset(n for n in raw_names if isinstance(n, str)) if isinstance(raw_names, list) else frozenset()
+    _active_suppress_private_public_siblings = bool(active_policy.get("reuse_suppress_private_public_siblings"))
+    _active_min_duplicate_count = max(2, int(active_policy.get("reuse_min_duplicate_count") or 2))
+
+
+def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -> dict[str, object]:
+    active_policy = policy(repo)
+    apply_active_policy(active_policy)
+    ctx = collect_scope(repo, base_ref)
+    changed_files = set(ctx.changed_files)
+    errors: list[str] = []
+    warnings: list[str] = []
+    conflict_files, temp_files = changed_file_failures(repo, changed_files)
+    quality_escapes = scan_quality_escapes(ctx)
+    duplicates = duplicate_added_blocks(ctx)
+    duplicates_all = duplicate_added_blocks_all(ctx)
+    bloat_errors, bloat_warnings, bloat_details = evaluate_bloat(ctx, active_policy)
+    reuse_findings = detect_reuse_issues(ctx, active_policy)
+    reuse_errors = [finding for finding in reuse_findings if finding.severity == "error"]
+    reuse_warnings = [finding for finding in reuse_findings if finding.severity == "warning"]
+
+    if conflict_files:
+        errors.append(f"merge conflict markers found in {len(conflict_files)} file(s)")
+    if temp_files:
+        errors.append(f"temporary artifact paths detected in {len(temp_files)} changed file(s)")
+    if quality_escapes:
+        errors.append(f"quality escapes detected in {len(quality_escapes)} changed location(s)")
+    advisory_groups = empty_advisory_groups()
+    advisory_groups["securityAssumptionFindings"]["added"].extend(scan_sensitive_input(ctx))
+    if duplicates:
+        errors.append(f"duplicate added code blocks detected: {len(duplicates)}")
+    if reuse_errors:
+        errors.append(f"new code appears to reimplement existing helpers or loops: {len(reuse_errors)}")
+    errors.extend(bloat_errors)
+    warnings.extend(bloat_warnings)
+    warnings.extend(reuse_warning_messages(reuse_warnings))
+    if fail_on_warnings and warnings:
+        errors.extend(f"warning promoted to failure: {warning}" for warning in warnings)
+
+    checks = quality_checks(conflict_files, temp_files, quality_escapes, duplicates, reuse_errors, reuse_warnings, bloat_errors, bloat_warnings)
+    return {
+        "ok": not errors,
+        "version": VERSION,
+        "repo": str(repo),
+        "changedFilesCount": len(changed_files),
+        "changedFilesSample": sorted(changed_files)[:30],
+        "sourceFilesCount": len([path for path in changed_files if is_production_source_path(path)]),
+        "checks": checks,
+        "hardRules": hard_rules(checks),
+        "errors": errors,
+        "warnings": warnings,
+        "bloat": bloat_details,
+        "reuseFindings": [finding.as_dict() for finding in reuse_findings],
+        "qualityEscapeLocations": list(quality_escapes),
+        "duplicateBlockCandidates": [{"count": int(d["count"]), "files": list(d["files"])} for d in duplicates_all],
+    }
+
+
+def reuse_warning_messages(reuse_warnings: list[ReuseFinding]) -> list[str]:
+    return [
+        f"possible reusable existing path for {finding.new_file}:{finding.new_line} -> {finding.existing_file}:{finding.existing_line} {finding.existing_symbol} ({finding.reason})"
+        for finding in reuse_warnings
+        **advisory_groups,
+
+
+def quality_checks(
+    conflict_files: list[str],
+    temp_files: list[str],
+    quality_escapes: list[str],
+    duplicates: list[dict[str, object]],
+    reuse_errors: list[ReuseFinding],
+    reuse_warnings: list[ReuseFinding],
+    bloat_errors: list[str],
+    bloat_warnings: list[str],
+) -> list[dict[str, object]]:
+    return [
+        {"name": "no-merge-conflict-markers", "passed": not conflict_files, "sample": conflict_files[:10]},
+        {"name": "no-temp-artifacts", "passed": not temp_files, "sample": temp_files[:10]},
+        {"name": "no-quality-escapes", "passed": not quality_escapes, "sample": quality_escapes[:10]},
+        {"name": "no-duplicate-added-blocks", "passed": not duplicates, "sample": duplicates[:4]},
+        {
+            "name": "reuse-existing-helpers",
+            "passed": not reuse_errors,
+            "warnings": [finding.as_dict() for finding in reuse_warnings[:10]],
+            "sample": [finding.as_dict() for finding in reuse_errors[:10]],
+        },
+        {"name": "risk-calibrated-bloat", "passed": not bloat_errors, "warnings": bloat_warnings[:10]},
+    ]
+
+
+def hard_rules(checks: list[dict[str, object]]) -> dict[str, dict[str, object]]:
+    passed = {str(item["name"]): bool(item["passed"]) for item in checks}
+    no_duplication = passed["no-duplicate-added-blocks"] and passed["reuse-existing-helpers"]
+    shortest_path = passed["risk-calibrated-bloat"] and no_duplication
+    return {
+        "codeVolume": {"passed": passed["risk-calibrated-bloat"], "checks": ["risk-calibrated-bloat"]},
+        "noDuplication": {"passed": no_duplication, "checks": ["no-duplicate-added-blocks", "reuse-existing-helpers"]},
+        "shortestPath": {"passed": shortest_path, "checks": ["risk-calibrated-bloat", "no-duplicate-added-blocks", "reuse-existing-helpers"]},
+        "cleanup": {"passed": passed["no-quality-escapes"] and passed["no-temp-artifacts"], "checks": ["no-quality-escapes", "no-temp-artifacts"]},
+        "anticipateConsequences": {"passed": passed["no-merge-conflict-markers"], "checks": ["no-merge-conflict-markers"]},
+        "simplicity": {"passed": shortest_path, "checks": ["risk-calibrated-bloat", "no-duplicate-added-blocks", "reuse-existing-helpers"]},
+    }
+
+
+def format_quality_text(result: dict[str, object]) -> str:
+    lines = [
+        "Lean Code Quality Gate",
+        f"verdict: {'pass' if result['ok'] else 'fail'}",
+        f"changedFilesCount: {result['changedFilesCount']}",
+        f"sourceFilesCount: {result['sourceFilesCount']}",
+        "",
+        "Checks:",
+def advisory_findings(result: dict[str, object]) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for group_name in ADVISORY_GROUP_NAMES:
+        group = result.get(group_name)
+        if not isinstance(group, dict):
+            continue
+        for bucket in ADVISORY_BUCKET_NAMES:
+            values = group.get(bucket)
+            if isinstance(values, list):
+                findings.extend(item for item in values if isinstance(item, dict))
+    return findings
+
+
+def format_advisory_sample(finding: dict[str, object]) -> str:
+    path = str(finding.get("path") or "unknown")
+    line = int(finding.get("line") or 0)
+    severity = str(finding.get("severity") or "warning")
+    rule = str(finding.get("rule") or "advisory")
+    message = str(finding.get("message") or "advisory finding")
+    location = f"{path}:{line}" if line else path
+    return f"- {severity} {rule} at {location}: {message}"
+
+
+    ]
+    for item in result["checks"]:
+        lines.append(f"- {item['name']}: {'pass' if item['passed'] else 'fail'}")
+    lines.append("")
+    lines.append("Errors:")
+    lines.extend([f"- {error}" for error in result["errors"]] if result["errors"] else ["- none"])
+    lines.append("")
+    lines.append("Warnings:")
+    lines.extend([f"- {warning}" for warning in result["warnings"]] if result["warnings"] else ["- none"])
+    return "\n".join(lines)
+
+
+def meaningful(values: object) -> bool:
+    if isinstance(values, str):
+        items = [values]
+    elif isinstance(values, list):
+        items = [str(item) for item in values]
+    findings = advisory_findings(result)
+    if findings:
+        lines.append("")
+        lines.append("Advisory findings:")
+        lines.extend(format_advisory_sample(finding) for finding in findings[:8])
+        if len(findings) > 8:
+            lines.append(f"- ... {len(findings) - 8} more advisory finding(s)")
+    else:
+        return False
+    return any(item.strip().lower() not in PLACEHOLDER_TEXT for item in items)
+
+
+def code_task(task_type: str) -> bool:
+    return task_type in {"bugfix", "feature", "refactor", "config"}
+
+
+def minimal_preflight(current_contract: dict[str, object]) -> bool:
+    return str(current_contract.get("preflight_level") or "full") == "minimal"
+
+
+def minimal_preflight_errors(current_contract: dict[str, object], active_policy: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    task_type = str(current_contract.get("task_type") or "unknown")
+    allowed = set(str(item) for item in active_policy.get("minimal_preflight_task_types", []))
+    if not active_policy.get("allow_minimal_preflight"):
+        errors.append("Minimal preflight is disabled by policy.")
+    if task_type not in allowed:
+        errors.append("Minimal preflight is limited to: " + ", ".join(sorted(allowed)))
+    if int(current_contract.get("max_files") or 0) > int(active_policy["minimal_preflight_max_files"]):
+        errors.append(f"Minimal preflight max-files cannot exceed {active_policy['minimal_preflight_max_files']}.")
+    if int(current_contract.get("max_added_lines") or 0) > int(active_policy["minimal_preflight_max_added_lines"]):
+        errors.append(f"Minimal preflight max-added-lines cannot exceed {active_policy['minimal_preflight_max_added_lines']}.")
+    if int(current_contract.get("max_changed_lines") or 0) > int(active_policy["minimal_preflight_max_changed_lines"]):
+        errors.append(f"Minimal preflight max-changed-lines cannot exceed {active_policy['minimal_preflight_max_changed_lines']}.")
+    for flag in ("allow_new_files", "allow_dependency_changes", "allow_bash_writes", "allow_abstractions", "allow_broad_scope"):
+        if current_contract.get(flag):
+            errors.append(f"Minimal preflight cannot use --{flag.replace('_', '-')}.")
+    return errors
+
+
+def contract_identity_errors(root: Path, current_contract: dict[str, object]) -> list[str]:
+    if not current_contract:
+        return []
+    identity = repo_identity(root)
+    stored_id = str(current_contract.get("repo_id") or "")
+    if not stored_id:
+        return [
+            "Lean Change Contract is missing repo_id. "
+            f"Redeclare for target repo_id {identity['repo_id']} at {identity['repo_root']}. "
+            f"State path: {contract_path(root)}. "
+            f"Run `{command_hint(root)} declare ...` to redeclare for the current repo."
+        ]
+    if stored_id != identity["repo_id"]:
+        stored_root = str(current_contract.get("repo_root") or "unknown")
+        return [
+            "Lean Change Contract belongs to "
+            f"repo_id {stored_id} at {stored_root}, but current target is "
+            f"repo_id {identity['repo_id']} at {identity['repo_root']}. "
+            f"State path: {contract_path(root)}. "
+            f"Run `{command_hint(root)} declare ...` to redeclare for the current repo."
+        ]
+    return []
+
+
+def contract_errors(current_contract: dict[str, object], active_policy: dict[str, object], root: Path | None = None) -> list[str]:
+    errors: list[str] = []
+    if not current_contract:
+        target = f" Target repo: {root.resolve()}. State path: {contract_path(root)}." if root is not None else ""
+        return [f"No active Lean Change Contract.{target} Run `{command_hint(root)} declare ...` before editing."]
+    if root is not None:
+        errors.extend(contract_identity_errors(root, current_contract))
+    if not meaningful(current_contract.get("intent")):
+        errors.append("Missing or placeholder intent.")
+    scope = current_contract.get("scope") or []
+    if not scope:
+        errors.append("Missing scope.")
+    broad = [glob for glob in scope if glob in BROAD_SCOPE or (str(glob).endswith("/**") and glob not in active_policy["allowed_broad_globs"])]
+    if broad and active_policy["block_broad_scope"] and not current_contract.get("allow_broad_scope"):
+        errors.append("Scope too broad: " + ", ".join(map(str, broad)) + ". Name exact files or narrow globs.")
+    if not current_contract.get("verify") and not current_contract.get("no_tests_reason"):
+        errors.append("Declare at least one verify command, or provide --no-tests-reason.")
+    task_type = str(current_contract.get("task_type") or "unknown")
+    if active_policy.get("require_explicit_task_type") and task_type == "unknown":
+        errors.append("Declare an explicit --task-type; unknown is not accepted for mutation contracts.")
+    if minimal_preflight(current_contract):
+        errors.extend(minimal_preflight_errors(current_contract, active_policy))
+        return errors
+    if active_policy["require_preflight_for_code"] and code_task(task_type):
+        required_fields = (
+            ("affected_surface", "--affected-surface"),
+            ("authoritative_contract", "--authoritative-contract"),
+            ("invariants", "--invariant"),
+            ("proof_plan", "--proof-plan"),
+            ("risk_check", "--risk-check"),
+        )
+        for field, flag in required_fields:
+            if not meaningful(current_contract.get(field)):
+                errors.append(f"Code work requires {flag}.")
+    if active_policy["require_reuse_path_for_code"] and task_type in {"bugfix", "feature", "refactor"}:
+        if not meaningful(current_contract.get("reuse_path")) and not meaningful(current_contract.get("no_reuse_reason")):
+            errors.append("Code work requires --reuse-path naming the existing path to extend, or --no-reuse-reason with evidence.")
+    return errors
+
+
+def check_change(change_facts: dict[str, object], current_contract: dict[str, object], active_policy: dict[str, object], tool: str) -> list[str]:
+    errors: list[str] = []
+    paths = list(change_facts["paths"])
+    scope = list(current_contract.get("scope") or [])
+    outside = [path for path in paths if not match(path, scope)]
+    if outside:
+        errors.append("Outside scope: " + ", ".join(outside) + ". Widen with a reason first.")
+    if len(paths) > int(current_contract["max_files"]):
+        errors.append(f"Touches {len(paths)} files, max is {current_contract['max_files']}.")
+    if int(change_facts["added"]) > int(current_contract["max_added_lines"]):
+        errors.append(f"Adds about {change_facts['added']} lines, max is {current_contract['max_added_lines']}.")
+    if int(change_facts["added"]) + int(change_facts["deleted"]) > int(current_contract["max_changed_lines"]):
+        errors.append(f"Changes about {int(change_facts['added']) + int(change_facts['deleted'])} lines, max is {current_contract['max_changed_lines']}.")
+    if change_facts.get("add_file") and not current_contract.get("allow_new_files"):
+        errors.append("New file requires --allow-new-files.")
+    deps = [path for path in paths if path_type(path) == "dependency"]
+    if deps and active_policy["block_dependency_changes_without_flag"] and not current_contract.get("allow_dependency_changes"):
+        errors.append("Undeclared dependency change: " + ", ".join(deps))
+    configs = [path for path in paths if path_type(path) == "config"]
+    if configs and active_policy["block_config_changes_without_flag"] and not current_contract.get("allow_config_changes"):
+        errors.append("Undeclared config change: " + ", ".join(configs))
+    text = str(change_facts.get("text") or "")
+    hits = design_hits(text)
+    if len(hits) >= int(active_policy["max_design_markers"]) and not current_contract.get("allow_abstractions"):
+        line_count = len(text.splitlines())
+        density_threshold = float(active_policy.get("max_design_marker_density_per_100_lines") or 0.0)
+        density = (len(hits) / line_count * 100) if line_count else 0.0
+        if line_count < 100 or density_threshold <= 0 or density >= density_threshold:
+            errors.append("Possible abstraction bloat: " + ", ".join(sorted(set(hits))) + ". Prefer direct code or redeclare with --allow-abstractions --reason.")
+    quality_hits = proposed_quality_hits(str(change_facts.get("text") or ""), paths)
+    if quality_hits:
+        errors.append("Proposed change contains quality escapes: " + ", ".join(quality_hits[:6]))
+    if tool == "Bash" and paths and not change_facts.get("patch_like") and active_policy["block_hidden_bash_writes"] and not current_contract.get("allow_bash_writes"):
+        errors.append("File-changing Bash is blocked; use Edit/apply_patch or declare --allow-bash-writes.")
+    return errors
+
+
+def proposed_quality_hits(text: str, paths: list[str]) -> list[str]:
+    if not text:
+        return []
+    target = next((path for path in paths if is_source_path(path)), "proposed-change")
+    rules = rules_for_path(target)
+    lines = list(enumerate(text.splitlines(), 1))
+    hits = line_hits(target, lines, rules)
+    hits.extend(multiline_hits(target, text))
+    return sorted(set(hits))
+
+
+def final_errors(root: Path, current_contract: dict[str, object], active_policy: dict[str, object]) -> list[str]:
+    if not current_contract:
+        snapshot = status_snapshot(root)
+        changed = sorted(
+            set(snapshot.get("status", {}))
+            | set(snapshot.get("numstat", {}))
+            | set(snapshot.get("untrackedLines", {}))
+        )
+        return ["Files changed but no Lean Change Contract exists: " + ", ".join(changed[:20])] if changed else []
+    current_delta = delta(root, current_contract)
+    errors = contract_errors(current_contract, active_policy, root)
+    files = list(current_delta["files"])
+    new_files = sorted(path for path in added_file_paths(root) if path in files)
+    if new_files and not current_contract.get("allow_new_files"):
+        errors.append("New files require --allow-new-files: " + ", ".join(new_files[:20]))
+    scope = list(current_contract.get("scope") or [])
+    outside = [path for path in files if not match(path, scope)]
+    if outside:
+        errors.append("Final diff outside scope: " + ", ".join(outside))
+    if len(files) > int(current_contract["max_files"]):
+        errors.append(f"Final diff touches {len(files)} files, max is {current_contract['max_files']}.")
+    if int(current_delta["added"]) > int(current_contract["max_added_lines"]):
+        errors.append(f"Final diff adds {current_delta['added']} lines, max is {current_contract['max_added_lines']}.")
+    if int(current_delta["changed"]) > int(current_contract["max_changed_lines"]):
+        errors.append(f"Final diff changes {current_delta['changed']} lines, max is {current_contract['max_changed_lines']}.")
+    deps = [path for path in files if path_type(path) == "dependency"]
+    if deps and active_policy["block_dependency_changes_without_flag"] and not current_contract.get("allow_dependency_changes"):
+        errors.append("Undeclared dependency changes: " + ", ".join(deps))
+    configs = [path for path in files if path_type(path) == "config"]
+    if configs and active_policy["block_config_changes_without_flag"] and not current_contract.get("allow_config_changes"):
+        errors.append("Undeclared config changes: " + ", ".join(configs))
+    prod_files = [path for path in files if path_type(path) == "prod"]
+    if current_contract.get("task_type") == "bugfix" and active_policy["require_bugfix_test_change"] and prod_files and not any(path_type(path) == "test" for path in files) and not current_contract.get("no_tests_reason"):
+        errors.append("Bugfix changed production code without a test change or --no-tests-reason.")
+    if prod_files and active_policy["require_preflight_for_code"] and not minimal_preflight(current_contract):
+        for field, flag in (("affected_surface", "--affected-surface"), ("authoritative_contract", "--authoritative-contract"), ("invariants", "--invariant"), ("proof_plan", "--proof-plan"), ("risk_check", "--risk-check")):
+            if not meaningful(current_contract.get(field)):
+                errors.append(f"Production diff requires {flag} in the contract.")
+    if prod_files and active_policy["require_reuse_path_for_code"] and not minimal_preflight(current_contract):
+        if not meaningful(current_contract.get("reuse_path")) and not meaningful(current_contract.get("no_reuse_reason")):
+            errors.append("Production diff requires --reuse-path naming the reused path or --no-reuse-reason with evidence.")
+    if active_policy["require_verify_after_mutation"] and files and not current_contract.get("no_tests_reason"):
+        wanted = [re.sub(r"\s+", " ", command.strip()) for command in current_contract.get("verify") or []]
+        passed = [
+            re.sub(r"\s+", " ", str(event.get("command", "")).strip())
+            for event in events(root)
+            if event.get("event") == "verify_passed" and float(event.get("time", 0)) >= float(current_contract.get("declared_at", 0))
+        ]
+        if wanted and not any(want in got or got in want for want in wanted for got in passed):
+            errors.append("Declared verification has not passed after mutation: " + " | ".join(wanted))
+    return errors
+
+
+def user_prompt(payload: dict[str, object]) -> None:
+    root = repo_root(str(payload.get("cwd") or "") or None)
+    prompt_hash = hashlib.sha256(str(payload.get("prompt") or "").encode()).hexdigest()[:16]
+    old = contract(root)
+    write_json(active_path(root), {"session_id": payload.get("session_id"), "turn_id": payload.get("turn_id"), "prompt_hash": prompt_hash, "at": time.time()})
+    if old and old.get("prompt_hash") != prompt_hash:
+        write_json(state_dir(root) / "previous_contract.json", old)
+        contract_path(root).unlink(missing_ok=True)
+    context(str(payload.get("hook_event_name") or "UserPromptSubmit"))
+
+
+def session_start(payload: dict[str, object]) -> None:
+    root = repo_root(str(payload.get("cwd") or "") or None)
+    write_json(active_path(root), {"session_id": payload.get("session_id"), "turn_id": payload.get("turn_id"), "at": time.time()})
+    context(str(payload.get("hook_event_name") or "SessionStart"))
+
+
+def declare(args: argparse.Namespace) -> None:
+    root = repo_root(args.cwd)
+    active_policy = policy(root)
+    active = read_json(active_path(root), {})
+    old = contract(root) if args.widen else {}
+    if args.widen and not args.reason:
+        print("Widening requires --reason.", file=sys.stderr)
+        raise SystemExit(2)
+    preflight_level = "minimal" if args.minimal_preflight else "full"
+    default_max_files = active_policy["minimal_preflight_max_files"] if args.minimal_preflight else active_policy["default_max_files"]
+    default_max_added = active_policy["minimal_preflight_max_added_lines"] if args.minimal_preflight else active_policy["default_max_added_lines"]
+    default_max_changed = active_policy["minimal_preflight_max_changed_lines"] if args.minimal_preflight else active_policy["default_max_changed_lines"]
+    identity = repo_identity(root)
+    current_contract = {
+        "version": VERSION,
+        **identity,
+        "intent": args.intent,
+        "scope": norm_list(args.scope),
+        "task_type": args.task_type,
+        "assumptions": args.assumption or [],
+        "affected_surface": args.affected_surface or [],
+        "authoritative_contract": args.authoritative_contract or [],
+        "invariants": args.invariant or [],
+        "proof_plan": args.proof_plan or [],
+        "reuse_path": args.reuse_path,
+        "no_reuse_reason": args.no_reuse_reason,
+        "preflight_level": preflight_level,
+        "chosen_approach": args.chosen_approach,
+        "rejected_alternatives": args.rejected_alternative or [],
+        "touchpoints": args.touchpoint or [],
+        "risk_check": args.risk_check or [],
+        "update": args.update or [],
+        "verify": args.verify or [],
+        "no_tests_reason": args.no_tests_reason,
+        "max_files": args.max_files or default_max_files,
+        "max_added_lines": args.max_added_lines or default_max_added,
+        "max_changed_lines": args.max_changed_lines or default_max_changed,
+        "base_ref": args.base_ref,
+        "allow_new_files": args.allow_new_files,
+        "allow_dependency_changes": args.allow_dependency_changes,
+        "allow_config_changes": args.allow_config_changes,
+        "allow_bash_writes": args.allow_bash_writes,
+        "allow_abstractions": args.allow_abstractions,
+        "allow_broad_scope": args.allow_broad_scope,
+        "allow_quality_warnings": args.allow_quality_warnings,
+        "reason": args.reason,
+        "declared_at": time.time(),
+        "prompt_hash": active.get("prompt_hash") if isinstance(active, dict) else None,
+        "baseline": baseline(root),
+        "widened_from": old or None,
+    }
+    errors = contract_errors(current_contract, active_policy, root)
+    if errors:
+        print("Lean Change Contract rejected:\n- " + "\n- ".join(errors), file=sys.stderr)
+        raise SystemExit(2)
+    write_json(contract_path(root), current_contract)
+    log_event(root, {"event": "contract_declared", "contract": current_contract})
+    print(json.dumps({"ok": True, "contract": current_contract}, indent=2, sort_keys=True))
+
+
+def pretool(payload: dict[str, object]) -> None:
+    tool = str(payload.get("tool_name") or "")
+    tool_input = payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
+    root = checked_hook_root("PreToolUse", payload, tool, tool_input)
+    if root is None:
+        return
+    if not mutating(tool, tool_input):
+        return
+    current_contract = contract(root)
+    active_policy = policy(root)
+    apply_active_policy(active_policy)
+    errors = contract_errors(current_contract, active_policy, root)
+    if errors:
+        deny("PreToolUse", "Lean Code Gate blocked mutation before contract:\n- " + "\n- ".join(errors))
+        return
+    command = tool_command(tool_input)
+    if tool == "Bash" and active_policy["block_hidden_bash_writes"] and not ("apply_patch" in command or "*** Begin Patch" in command or "diff --git" in command) and not current_contract.get("allow_bash_writes"):
+        deny("PreToolUse", "Hidden file-changing Bash blocked. Use Edit/apply_patch or redeclare --allow-bash-writes with a reason.")
+        return
+    change_facts = hook_facts(payload, root, tool, tool_input)
+    errors = check_change(change_facts, current_contract, active_policy, tool)
+    if errors:
+        deny("PreToolUse", "Lean Code Gate blocked over-broad or low-quality mutation:\n- " + "\n- ".join(errors))
+        return
+    remember_target_root(payload, root)
+    log_event(root, {"event": "mutation_allowed", "tool": tool, **{key: change_facts[key] for key in ("paths", "added", "deleted")}})
+
+
+def permission_request(payload: dict[str, object]) -> None:
+    tool = str(payload.get("tool_name") or "")
+    tool_input = payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
+    root = checked_hook_root("PermissionRequest", payload, tool, tool_input)
+    if root is None:
+        return
+    if mutating(tool, tool_input):
+        errors = contract_errors(contract(root), policy(root), root)
+        if errors:
+            deny("PermissionRequest", "Mutation approval denied:\n- " + "\n- ".join(errors))
+
+
+def posttool(payload: dict[str, object], failed: bool = False) -> None:
+    tool = str(payload.get("tool_name") or "")
+    tool_input = payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
+    root = checked_hook_root(None, payload, tool, tool_input)
+    if root is None:
+        return
+    if mutating(tool, tool_input):
+        log_event(root, {"event": "mutation_failed" if failed else "mutation_finished", "tool": tool, **hook_facts(payload, root, tool, tool_input)})
+    command = tool_command(tool_input)
+    if tool == "Bash" and verify_cmd(command):
+        response = payload.get("tool_response")
+        exit_code = response_exit_code(response)
+        command_failed = failed or (exit_code is not None and exit_code != 0)
+        for verify_root in stop_roots(payload):
+            log_event(verify_root, {"event": "verify_failed" if command_failed else "verify_passed", "command": command, "exit_code": exit_code})
+
+
+def stop(payload: dict[str, object]) -> None:
+    roots = stop_roots(payload)
+    if not roots:
+        return
+    all_errors: list[str] = []
+    if payload.get("stop_hook_active"):
+        for root in roots:
+            issues = final_errors(root, contract(root), policy(root))
+            all_errors.extend(f"{root}: {issue}" if len(roots) > 1 else issue for issue in issues)
+        issues = all_errors
+        if issues:
+            emit({"systemMessage": "Lean Code Gate still has unresolved issues after a Stop continuation: " + " | ".join(issues[:8])})
+        return
+    for root in roots:
+        current_contract = contract(root)
+        active_policy = policy(root)
+        errors = final_errors(root, current_contract, active_policy)
+        if active_policy["run_quality_gate_on_stop"]:
+            fail_warnings = bool(active_policy["fail_on_quality_warnings"]) and not (current_contract or {}).get("allow_quality_warnings")
+            quality = run_quality_gate(root, str((current_contract or {}).get("base_ref") or "") or None, fail_warnings)
+            if not quality["ok"]:
+                errors.extend(["Quality gate failed: " + error for error in quality["errors"]])
+        all_errors.extend(f"{root}: {error}" if len(roots) > 1 else error for error in errors)
+    if all_errors:
+        deny(
+            "Stop",
+            "Lean Code Gate final check failed:\n- "
+            + "\n- ".join(all_errors)
+            + "\nReduce the diff, remove bloat/escapes/duplication, run verification, or widen with a concrete reason.",
+        )
+
+
+def status(args: argparse.Namespace) -> None:
+    root = repo_root(args.cwd)
+    current_contract = contract(root)
+    identity = repo_identity(root)
+    runtime = {
+        "cwd": os.getcwd(),
+        "env_repo_root": os.environ.get("LEAN_CODE_GATE_REPO_ROOT") or "",
+        "contract_path": str(contract_path(root)),
+        "contract_repo_id": str(current_contract.get("repo_id") or "") if current_contract else "",
+        "contract_matches_repo": not contract_identity_errors(root, current_contract) if current_contract else False,
+        **identity,
+    }
+    print(json.dumps({"runtime": runtime, "contract": current_contract, "delta": delta(root, current_contract) if current_contract else {}, "policy": policy(root)}, indent=2, sort_keys=True))
+
+
+def reset(args: argparse.Namespace) -> None:
+    root = repo_root(args.cwd)
+    for name in ("active.json", "contract.json", "previous_contract.json", "events.jsonl"):
+        (state_dir(root) / name).unlink(missing_ok=True)
+    print("Lean Code Gate state reset.")
+
+
+def check_command(args: argparse.Namespace) -> int:
+    root = repo_root(args.repo)
+    if not git_ok(root, ["rev-parse", "--show-toplevel"]):
+        print(f"ERROR: not a git repository: {root}", file=sys.stderr)
+        return 1
+    result = run_quality_gate(root, args.base_ref or None, args.fail_on_warnings)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(format_quality_text(result))
+        print("")
+        print(json.dumps(result, sort_keys=True))
+    return 0 if result["ok"] else 2
+
+
+def parser() -> argparse.ArgumentParser:
+    root_parser = argparse.ArgumentParser(description="Lean Code Gate v3 hook + contract + quality CLI")
+    sub = root_parser.add_subparsers(dest="cmd", required=True)
+    for name in ["user-prompt", "session-start", "pretool", "permission-request", "posttool", "posttool-failure", "stop"]:
+        sub.add_parser(name)
+    declare_parser = sub.add_parser("declare")
+    declare_parser.add_argument("--cwd")
+    declare_parser.add_argument("--intent", required=True)
+    declare_parser.add_argument("--scope", required=True)
+    declare_parser.add_argument("--task-type", choices=["bugfix", "feature", "refactor", "test", "docs", "config", "unknown"], default="unknown")
+    declare_parser.add_argument("--minimal-preflight", "--lean", dest="minimal_preflight", action="store_true")
+    declare_parser.add_argument("--assumption", action="append", default=[])
+    declare_parser.add_argument("--affected-surface", action="append", default=[])
+    declare_parser.add_argument("--authoritative-contract", action="append", default=[])
+    declare_parser.add_argument("--invariant", action="append", default=[])
+    declare_parser.add_argument("--proof-plan", action="append", default=[])
+    declare_parser.add_argument("--reuse-path", default="")
+    declare_parser.add_argument("--no-reuse-reason", default="")
+    declare_parser.add_argument("--chosen-approach", default="")
+    declare_parser.add_argument("--rejected-alternative", action="append", default=[])
+    declare_parser.add_argument("--touchpoint", action="append", default=[])
+    declare_parser.add_argument("--risk-check", action="append", default=[])
+    declare_parser.add_argument("--update", action="append", default=[])
+    declare_parser.add_argument("--verify", action="append", default=[])
+    declare_parser.add_argument("--max-files", type=int)
+    declare_parser.add_argument("--max-added-lines", type=int)
+    declare_parser.add_argument("--max-changed-lines", type=int)
+    declare_parser.add_argument("--no-tests-reason", default="")
+    declare_parser.add_argument("--reason", default="")
+    declare_parser.add_argument("--base-ref", default="")
+    declare_parser.add_argument("--widen", action="store_true")
+    for flag in [
+        "allow-new-files",
+        "allow-dependency-changes",
+        "allow-config-changes",
+        "allow-bash-writes",
+        "allow-abstractions",
+        "allow-broad-scope",
+        "allow-quality-warnings",
+    ]:
+        declare_parser.add_argument("--" + flag, action="store_true")
+    status_parser = sub.add_parser("status")
+    status_parser.add_argument("--cwd")
+    reset_parser = sub.add_parser("reset")
+    reset_parser.add_argument("--cwd")
+    check_parser = sub.add_parser("check")
+    check_parser.add_argument("--repo", default=os.getcwd())
+    check_parser.add_argument("--base-ref", default="")
+    check_parser.add_argument("--json", action="store_true")
+    check_parser.add_argument("--fail-on-warnings", action="store_true")
+    return root_parser
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if args.cmd == "declare":
+        declare(args)
+    elif args.cmd == "status":
+        status(args)
+    elif args.cmd == "reset":
+        reset(args)
+    elif args.cmd == "check":
+        return check_command(args)
+    else:
+        payload = hook_input()
+        dispatch = {
+            "user-prompt": user_prompt,
+            "session-start": session_start,
+            "pretool": pretool,
+            "permission-request": permission_request,
+            "posttool": posttool,
+            "posttool-failure": lambda value: posttool(value, True),
+            "stop": stop,
+        }
+        dispatch[args.cmd](payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/lean-code/SKILL.md
+++ b/.agents/skills/lean-code/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: lean-code
+description: Enforce minimal, surgical, verified production code changes. Use whenever writing, editing, fixing, refactoring, reviewing, or testing code to prevent overengineering, broad diffs, duplicate helpers, fake-green suppressions, dependency churn, and unverified changes.
+---
+
+# Lean Code Gate v3
+
+Use this skill for every task that may modify code, tests, build files, config, generated source, scripts, dependency metadata, or docs generated from code.
+
+The goal is the smallest correct production diff. The gate script is authoritative; the prose is just here because apparently agents still need a bedtime story before not ruining a repository.
+
+For global installs, set `LEAN_CODE_GATE_SCRIPT_PATH` to the gate script path shown by the hook reminder and call that script directly from the hook command. Do not set `LEAN_CODE_GATE_REPO_ROOT` in the normal global hook template; use it only as a fallback for hooks or runtimes that cannot provide the target working directory. The runtime prefers hook-supplied `workdir`/`cwd` when available, including Codex `cmd`/`workdir` and Claude `command`/`cwd` payloads.
+
+The gate keeps runtime state in the target repo at `.agent/lean/state/`. That state is intentionally repo-local, stamped with a repo id, ignored by gate diff checks, and should not be deleted during active work. Run `status` when root selection is unclear; it prints the resolved repo root, repo id, state path, and whether the active contract matches.
+
+After upgrading to repo-id state, older unstamped contracts must be redeclared once.
+
+## Required order
+
+1. Inspect before editing.
+2. Choose the smallest viable contract: minimal preflight for micro-fixes, full preflight for larger production work.
+3. Declare the Lean Change Contract before the first mutating tool call.
+4. Edit only files inside the declared scope.
+5. Stay inside file and line budgets.
+6. Run the declared verification command after mutation.
+7. Let the final stop hook run the quality gate before completion.
+
+## Minimal preflight for micro-fixes
+
+Use this only for small, obvious edits: default budget is at most 2 files, 30 added lines, and 80 changed lines. It cannot use broad scope, new files, dependency changes, Bash writes, or abstraction escape hatches.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare \
+  --minimal-preflight \
+  --intent "one sentence describing the exact micro-fix" \
+  --scope "src/exact_file.py,tests/test_exact_file.py" \
+  --task-type bugfix \
+  --verify "pytest tests/test_exact_file.py"
+```
+
+Minimal preflight is not a loophole. If the final diff exceeds the micro budget, widen with evidence or redeclare full preflight.
+
+## Full production preflight
+
+Use full preflight for features, refactors, multi-file bug fixes, new behavior, or any task with unclear blast radius.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare \
+  --intent "one sentence describing the exact requested outcome" \
+  --scope "src/exact_file.py,tests/test_exact_file.py" \
+  --task-type bugfix \
+  --affected-surface "changed boundary plus adjacent callers/no-change surfaces" \
+  --authoritative-contract "observable invariant, API contract, or external requirement" \
+  --invariant "observable condition proving the contract" \
+  --reuse-path "existing helper/module/pattern to extend" \
+  --proof-plan "focused regression test plus adjacent invariant check" \
+  --risk-check "specific regression or failure mode being guarded" \
+  --max-files 2 \
+  --max-added-lines 80 \
+  --max-changed-lines 160 \
+  --verify "pytest tests/test_exact_file.py"
+```
+
+When no existing path fits, use `--no-reuse-reason "specific evidence"` instead of inventing a fake reuse path.
+
+## Contract rules
+
+- `--task-type` is mandatory in practice. `unknown` is rejected for mutation contracts.
+- `--scope` must name exact files or narrow globs.
+- `--verify` is required unless `--no-tests-reason` gives a concrete reason.
+- Full production work requires affected surface, authoritative contract, invariant, proof plan, risk check, and reuse path or no-reuse reason.
+- Placeholder values like `none`, `n/a`, `unknown`, and `tbd` do not satisfy required fields.
+
+Allowed task types: `bugfix`, `feature`, `refactor`, `test`, `docs`, `config`, `unknown`.
+
+## Widening
+
+Only widen after inspection proves the original contract is wrong or incomplete.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare \
+  --widen \
+  --reason "new evidence requiring wider scope or budget" \
+  --intent "..." \
+  --scope "exact/file/a.ts,exact/file/b.ts,tests/exact.test.ts" \
+  --task-type bugfix \
+  --affected-surface "..." \
+  --authoritative-contract "..." \
+  --invariant "..." \
+  --reuse-path "..." \
+  --proof-plan "..." \
+  --risk-check "..." \
+  --verify "pnpm test exact.test.ts"
+```
+
+Escape hatches need evidence:
+
+- `--allow-new-files`: user requested a new file or no existing file is appropriate.
+- `--allow-dependency-changes`: user explicitly requested dependency work or correctness requires it.
+- `--allow-config-changes`: config files are the target.
+- `--allow-abstractions`: at least two current call sites need the abstraction now.
+- `--allow-bash-writes`: Edit/apply_patch cannot express the change safely.
+- `--allow-quality-warnings`: the warning is understood and accepted.
+- `--no-tests-reason "..."`: only for changes that cannot reasonably be verified by tests.
+
+## Implementation rules
+
+- Minimum code that solves the requested behavior.
+- Extend existing implementation before adding a parallel one.
+- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, or configuration knobs.
+- No new package if standard library or an existing package solves the problem cleanly.
+- No second package manager or second lockfile.
+- No broad error handling for impossible scenarios.
+- Treat reads from environment, credential files, keyrings, auth/cookie headers, private keys, or git remote URLs as sensitive input; name the risk in `--risk-check` and never log, serialize, cache, snapshot, or emit the values.
+- No fake-green patterns: `|| true`, blanket suppressions, broad catch/pass, empty catch, `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `# type: ignore`, `# noqa`.
+- No `TODO`, `FIXME`, `HACK`, placeholders, dummy adapters, temporary bypasses, or unfinished stubs in changed source.
+- Delete only orphans created by your own change.
+- Do not clean unrelated legacy debt unless the user asked.
+
+## Verification rules
+
+For bug fixes:
+
+1. Add or update the smallest test that reproduces the bug.
+2. Make it pass with the smallest production change.
+3. Run the declared focused verification.
+4. Run broader checks only when the affected surface requires them.
+
+For refactors:
+
+1. Establish current behavior with a relevant check when practical.
+2. Make the smallest behavior-preserving change.
+3. Run the same check after.
+4. Do not add behavior.
+
+Before final completion, the stop hook runs the built-in gate. CI/pre-commit can run the same gate directly:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py check --repo "$PWD"
+```
+
+The quality gate fails on changed-scope evidence of merge conflict markers, temp artifacts, fake-green suppressions, duplicate added blocks, high-confidence helper reimplementation, and risk-calibrated bloat. Lower-confidence reuse and moderate large-file growth are warnings by default.
+
+## Final response shape
+
+Report only:
+
+- Contract: intent, files, budget used.
+- Changed: concise file-by-file summary.
+- Verified: commands run and result.
+- Not done: explicit gaps, if any.
+
+Do not include speculative future improvements unless the user asked for them.

--- a/.claude/skills/lean-code/SKILL.md
+++ b/.claude/skills/lean-code/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: lean-code
+description: Enforce minimal, surgical, verified production code changes. Use whenever writing, editing, fixing, refactoring, reviewing, or testing code to prevent overengineering, broad diffs, duplicate helpers, fake-green suppressions, dependency churn, and unverified changes.
+---
+
+# Lean Code Gate v3
+
+Use this skill for every task that may modify code, tests, build files, config, generated source, scripts, dependency metadata, or docs generated from code.
+
+The goal is the smallest correct production diff. The gate script is authoritative; the prose is just here because apparently agents still need a bedtime story before not ruining a repository.
+
+For global installs, set `LEAN_CODE_GATE_SCRIPT_PATH` to the gate script path shown by the hook reminder and call that script directly from the hook command. Do not set `LEAN_CODE_GATE_REPO_ROOT` in the normal global hook template; use it only as a fallback for hooks or runtimes that cannot provide the target working directory. The runtime prefers hook-supplied `workdir`/`cwd` when available, including Codex `cmd`/`workdir` and Claude `command`/`cwd` payloads.
+
+The gate keeps runtime state in the target repo at `.agent/lean/state/`. That state is intentionally repo-local, stamped with a repo id, ignored by gate diff checks, and should not be deleted during active work. Run `status` when root selection is unclear; it prints the resolved repo root, repo id, state path, and whether the active contract matches.
+
+After upgrading to repo-id state, older unstamped contracts must be redeclared once.
+
+## Required order
+
+1. Inspect before editing.
+2. Choose the smallest viable contract: minimal preflight for micro-fixes, full preflight for larger production work.
+3. Declare the Lean Change Contract before the first mutating tool call.
+4. Edit only files inside the declared scope.
+5. Stay inside file and line budgets.
+6. Run the declared verification command after mutation.
+7. Let the final stop hook run the quality gate before completion.
+
+## Minimal preflight for micro-fixes
+
+Use this only for small, obvious edits: default budget is at most 2 files, 30 added lines, and 80 changed lines. It cannot use broad scope, new files, dependency changes, Bash writes, or abstraction escape hatches.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare \
+  --minimal-preflight \
+  --intent "one sentence describing the exact micro-fix" \
+  --scope "src/exact_file.py,tests/test_exact_file.py" \
+  --task-type bugfix \
+  --verify "pytest tests/test_exact_file.py"
+```
+
+Minimal preflight is not a loophole. If the final diff exceeds the micro budget, widen with evidence or redeclare full preflight.
+
+## Full production preflight
+
+Use full preflight for features, refactors, multi-file bug fixes, new behavior, or any task with unclear blast radius.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare \
+  --intent "one sentence describing the exact requested outcome" \
+  --scope "src/exact_file.py,tests/test_exact_file.py" \
+  --task-type bugfix \
+  --affected-surface "changed boundary plus adjacent callers/no-change surfaces" \
+  --authoritative-contract "observable invariant, API contract, or external requirement" \
+  --invariant "observable condition proving the contract" \
+  --reuse-path "existing helper/module/pattern to extend" \
+  --proof-plan "focused regression test plus adjacent invariant check" \
+  --risk-check "specific regression or failure mode being guarded" \
+  --max-files 2 \
+  --max-added-lines 80 \
+  --max-changed-lines 160 \
+  --verify "pytest tests/test_exact_file.py"
+```
+
+When no existing path fits, use `--no-reuse-reason "specific evidence"` instead of inventing a fake reuse path.
+
+## Contract rules
+
+- `--task-type` is mandatory in practice. `unknown` is rejected for mutation contracts.
+- `--scope` must name exact files or narrow globs.
+- `--verify` is required unless `--no-tests-reason` gives a concrete reason.
+- Full production work requires affected surface, authoritative contract, invariant, proof plan, risk check, and reuse path or no-reuse reason.
+- Placeholder values like `none`, `n/a`, `unknown`, and `tbd` do not satisfy required fields.
+
+Allowed task types: `bugfix`, `feature`, `refactor`, `test`, `docs`, `config`, `unknown`.
+
+## Widening
+
+Only widen after inspection proves the original contract is wrong or incomplete.
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py declare \
+  --widen \
+  --reason "new evidence requiring wider scope or budget" \
+  --intent "..." \
+  --scope "exact/file/a.ts,exact/file/b.ts,tests/exact.test.ts" \
+  --task-type bugfix \
+  --affected-surface "..." \
+  --authoritative-contract "..." \
+  --invariant "..." \
+  --reuse-path "..." \
+  --proof-plan "..." \
+  --risk-check "..." \
+  --verify "pnpm test exact.test.ts"
+```
+
+Escape hatches need evidence:
+
+- `--allow-new-files`: user requested a new file or no existing file is appropriate.
+- `--allow-dependency-changes`: user explicitly requested dependency work or correctness requires it.
+- `--allow-config-changes`: config files are the target.
+- `--allow-abstractions`: at least two current call sites need the abstraction now.
+- `--allow-bash-writes`: Edit/apply_patch cannot express the change safely.
+- `--allow-quality-warnings`: the warning is understood and accepted.
+- `--no-tests-reason "..."`: only for changes that cannot reasonably be verified by tests.
+
+## Implementation rules
+
+- Minimum code that solves the requested behavior.
+- Extend existing implementation before adding a parallel one.
+- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, or configuration knobs.
+- No new package if standard library or an existing package solves the problem cleanly.
+- No second package manager or second lockfile.
+- No broad error handling for impossible scenarios.
+- Treat reads from environment, credential files, keyrings, auth/cookie headers, private keys, or git remote URLs as sensitive input; name the risk in `--risk-check` and never log, serialize, cache, snapshot, or emit the values.
+- No fake-green patterns: `|| true`, blanket suppressions, broad catch/pass, empty catch, `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `# type: ignore`, `# noqa`.
+- No `TODO`, `FIXME`, `HACK`, placeholders, dummy adapters, temporary bypasses, or unfinished stubs in changed source.
+- Delete only orphans created by your own change.
+- Do not clean unrelated legacy debt unless the user asked.
+
+## Verification rules
+
+For bug fixes:
+
+1. Add or update the smallest test that reproduces the bug.
+2. Make it pass with the smallest production change.
+3. Run the declared focused verification.
+4. Run broader checks only when the affected surface requires them.
+
+For refactors:
+
+1. Establish current behavior with a relevant check when practical.
+2. Make the smallest behavior-preserving change.
+3. Run the same check after.
+4. Do not add behavior.
+
+Before final completion, the stop hook runs the built-in gate. CI/pre-commit can run the same gate directly:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py check --repo "$PWD"
+```
+
+The quality gate fails on changed-scope evidence of merge conflict markers, temp artifacts, fake-green suppressions, duplicate added blocks, high-confidence helper reimplementation, and risk-calibrated bloat. Lower-confidence reuse and moderate large-file growth are warnings by default.
+
+## Final response shape
+
+Report only:
+
+- Contract: intent, files, budget used.
+- Changed: concise file-by-file summary.
+- Verified: commands run and result.
+- Not done: explicit gaps, if any.
+
+Do not include speculative future improvements unless the user asked for them.

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -1,0 +1,124 @@
+# Lean Code Gate v3 methodology
+
+## Objective
+
+Force coding agents toward senior-engineer behavior by replacing advisory Markdown with deterministic gates.
+
+The gate optimizes for:
+
+- smallest correct diff
+- explicit affected surface for non-trivial code work
+- reuse before new code
+- no speculative abstractions
+- no fake-green suppressions
+- no hidden mutation
+- verified completion
+
+## What changed from v2
+
+| Critique | V3 change |
+|---|---|
+| GitNexus references leaked into a portable package | Removed all GitNexus query emission and JSON fields |
+| Reuse detector had too much authority for a heuristic | Default mode is conservative: only high-confidence matches fail; weaker signals warn |
+| Reuse detector had thin tests | Added coverage for dedupe loops, generic-name false positives, same-token/different-domain cases, deleted-then-recreated helpers, and polyglot same names |
+| One-line bug fixes required nine free-text fields | Added `--minimal-preflight` / `--lean` for micro-fixes with hard size and escape-hatch limits |
+| `task_type=unknown` triggered confusing preflight behavior | `unknown` is now rejected for mutation contracts when explicit task type is required |
+| Large-file defaults were too aggressive for drop-in repos | Large existing files may grow slightly with a warning; large growth still fails. Old must-shrink behavior is policy-controlled |
+| Stop-time final checks missed manually added files | Final check now blocks new files unless `--allow-new-files` is declared |
+| Verify accounting depended on loose response text | Verification exit-code extraction now walks nested hook responses before falling back to text parsing |
+
+## What was retained from the legacy gate
+
+The legacy gate had several high-value enforcement ideas. V3 keeps the useful deterministic parts and removes environment-specific dependencies.
+
+| Legacy idea | V3 implementation |
+|---|---|
+| Production preflight | Full contract fields: `affected_surface`, `authoritative_contract`, `invariants`, `reuse_path` or `no_reuse_reason`, `proof_plan`, `risk_check` |
+| Existing path / reuse discipline | Required reuse field for full production work plus changed-scope high-confidence reimplementation detector |
+| Fake-green cleanup scan | Added-line and untracked-source scans for suppressions, `|| true`, broad catch/pass, empty catch, TODO/FIXME/HACK |
+| Duplicate added-code scan | Rolling-window duplicate added-block detector |
+| Risk-calibrated bloat | New-file, large-file-growth, per-file-growth, and additive-total thresholds |
+| Temp artifact / merge-marker scan | Final quality gate checks changed scope |
+| Six hard rules | Exposed as `codeVolume`, `noDuplication`, `shortestPath`, `cleanup`, `anticipateConsequences`, `simplicity` |
+
+## What was intentionally not copied
+
+- Repo Context Forge bootstrap paths.
+- GitNexus-specific commands.
+- PR quiet-window and delegated-agent governance.
+- Environment-specific model defaults.
+
+Those may be useful in one stack but are brittle as a portable baseline. V3 accepts human-written affected-surface evidence through the contract instead of depending on unavailable tools.
+
+## Enforcement layers
+
+1. **Skill file**: tells the agent how to work.
+2. **UserPromptSubmit / SessionStart hook**: injects the gate reminder each turn.
+3. **Declare command**: stores the Lean Change Contract and baseline diff.
+4. **PreToolUse hook**: blocks mutation without a valid contract or outside the contract.
+5. **PermissionRequest hook**: denies approval escalation for mutation without a contract.
+6. **PostToolUse hook**: records mutations and successful verification commands.
+7. **Stop hook**: blocks final completion if verification, scope, budget, preflight, or quality checks fail.
+8. **Standalone `check` command**: lets CI/pre-commit run the same quality gate.
+
+## Contract model
+
+Minimal preflight binds the agent to exact intent, exact scope, explicit task type, small budgets, and focused verification. It is intended for micro-fixes only.
+
+Full preflight additionally binds the agent to affected surface, authoritative contract, invariant, reuse path or no-reuse reason, proof plan, and risk checks.
+
+Widening must redeclare the contract with `--widen --reason "..."`.
+
+## Quality model
+
+The final quality gate inspects the changed source scope and fails on:
+
+- merge conflict markers
+- temporary artifact paths
+- fake-green suppressions
+- broad catch/pass and empty catch blocks
+- TODO/FIXME/HACK in changed source
+- TypeScript `any`/double-cast shortcuts in production source
+- Python `Any`/`cast` shortcuts in production source
+- duplicate added code blocks
+- high-confidence helper or loop reimplementation
+- risk-calibrated bloat
+
+The advisory surface also reports sensitive-input reads when changed code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value.
+
+Warnings are emitted for moderate bloat and weaker reuse signals. Projects can promote warnings to failures in `.agent/lean/policy.json`.
+
+## Operating guidance
+
+Recommended rollout:
+
+1. Install the package in a repo root.
+2. Trust project hooks in Codex or enable project settings in Claude Code.
+3. Run `PYTHONDONTWRITEBYTECODE=1 python3 -B -S .agent/lean/lean_code_gate.py check --repo "$PWD"` locally.
+4. Use default thresholds for a week.
+5. Tune policy only for measured false positives.
+6. Add the `check` command to CI or pre-commit for bypass resistance.
+
+### Codex global script and target root
+
+The default Codex config assumes the gate script is installed in the target repo at `.agent/lean/lean_code_gate.py`.
+
+If Codex hooks call a shared/global copy instead, set `LEAN_CODE_GATE_SCRIPT_PATH` to that script path in the hook environment and call that same script directly. Do not set `LEAN_CODE_GATE_REPO_ROOT` in the normal global hook template; hard-coding it pins every controller-session mutation to one repo and prevents nested target repos from owning their own `.agent/lean/state`.
+
+Minimal global Codex hook command shape:
+
+```toml
+command = 'LEAN_CODE_GATE_SCRIPT_PATH="$HOME/.codex/lean-code-gate-v3/lean_code_gate.py" PYTHONDONTWRITEBYTECODE=1 python3 -B -S "$HOME/.codex/lean-code-gate-v3/lean_code_gate.py" pretool'
+```
+
+Use the same prefix and script path for `session-start`, `user-prompt`, `permission-request`, `posttool`, and `stop`. Keep the bundled repo-local `.codex/config.toml` shape when installing inside a single target repo; it resolves the repo-local script with `git rev-parse --show-toplevel` and also does not set `LEAN_CODE_GATE_REPO_ROOT`.
+
+For existing Codex installs, remove any hard-coded `LEAN_CODE_GATE_REPO_ROOT` from the hook commands and restart the Codex session so the edited config is reloaded.
+
+When hooks include a target working directory, the runtime prefers that repo over `LEAN_CODE_GATE_REPO_ROOT`; Codex `cmd`/`workdir` and Claude `command`/`cwd` payloads are both supported. If a controller folder contains nested git repos but the hook payload omits the target workdir, the gate infers from changed file paths when possible and otherwise fails closed instead of writing controller state. Set `LEAN_CODE_GATE_REPO_ROOT` only as a fallback for hooks or runtimes that cannot provide the target working directory. Policy, state, diff checks, and verification status then stay anchored to the resolved target repo. Repo-local `.agent/lean/policy.json` remains optional for per-project policy overrides.
+
+The gate stores runtime state under the resolved target repo at `.agent/lean/state/`. Contracts are stamped with a repo id derived from the repo root and git common dir; the raw origin URL is not read or persisted. A contract from another repo or from an older unstamped runtime is rejected instead of being reused silently. Moving a clone or switching worktrees intentionally requires redeclaring the active contract for that target. Runtime state and Python bytecode under `.agent/lean/` are ignored by diff and final checks, but should not be deleted during active work because they record the current contract and verification events. Use `status` to see the target repo, repo id, state path, and whether the active contract matches.
+
+## Limits
+
+The gate is deterministic, not omniscient. It does not prove semantic correctness or global design optimality. It prevents common failure modes that correlate with bloated agent diffs: wide scope, hidden writes, duplicate code, fake green, unverified edits, and unchecked growth. That is not magic, which is rude, but it is enforceable.

--- a/tests/test_lean_code_gate.py
+++ b/tests/test_lean_code_gate.py
@@ -1,0 +1,1362 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE = ROOT / ".agent" / "lean" / "lean_code_gate.py"
+
+
+def run_gate(
+    repo: Path,
+    *args: str,
+    payload: dict[str, object] | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", "-B", "-S", str(GATE), *args],
+        cwd=repo,
+        input=json.dumps(payload) if payload is not None else None,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=20,
+        env={**os.environ, "LEAN_CODE_GATE_REPO_ROOT": "", "LEAN_CODE_GATE_SCRIPT_PATH": "", **(env or {})},
+    )
+
+
+def git(repo: Path, *args: str) -> None:
+    env = {
+        **os.environ,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_EDITOR": "true",
+        "GIT_PAGER": "cat",
+    }
+    result = subprocess.run(
+        ["git", "-c", "gc.auto=0", "-c", "maintenance.auto=false", *args],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+
+
+@contextmanager
+def repo_fixture() -> Iterator[Path]:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp)
+        init_repo_fixture(repo)
+        yield repo
+
+
+def init_repo_fixture(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / ".agent" / "lean").mkdir(parents=True)
+    shutil.copy2(GATE, repo / ".agent" / "lean" / "lean_code_gate.py")
+    (repo / "src").mkdir()
+    (repo / "tests").mkdir()
+    (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\n", encoding="utf-8")
+    (repo / "tests" / "test_app.py").write_text(
+        "from src.app import add\n\ndef test_add():\n    assert add(1, 2) == 3\n",
+        encoding="utf-8",
+    )
+    git(repo, "init")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test User")
+    git(repo, "add", ".")
+    git(repo, "commit", "--no-gpg-sign", "-m", "init")
+
+
+def declare_valid(repo: Path, *, task_type: str = "feature", scope: str = "src/app.py,tests/test_app.py") -> None:
+    result = run_gate(
+        repo,
+        "declare",
+        "--intent",
+        "adjust add behavior",
+        "--scope",
+        scope,
+        "--task-type",
+        task_type,
+        "--affected-surface",
+        "add function and direct unit test",
+        "--authoritative-contract",
+        "add returns the requested arithmetic result",
+        "--invariant",
+        "existing add callers remain valid",
+        "--reuse-path",
+        "src/app.py add function",
+        "--proof-plan",
+        "pytest tests/test_app.py",
+        "--risk-check",
+        "addition behavior regression",
+        "--verify",
+        "pytest tests/test_app.py",
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def declare_minimal(repo: Path) -> None:
+    result = run_gate(
+        repo,
+        "declare",
+        "--minimal-preflight",
+        "--intent",
+        "fix small add bug",
+        "--scope",
+        "src/app.py,tests/test_app.py",
+        "--task-type",
+        "bugfix",
+        "--verify",
+        "pytest tests/test_app.py",
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def check_json(repo: Path, *args: str) -> tuple[int, dict[str, object]]:
+    result = run_gate(repo, "check", "--repo", str(repo), "--json", *args)
+    return result.returncode, json.loads(result.stdout)
+
+
+def snapshot_paths(repo: Path) -> set[str]:
+    return {str(path.relative_to(repo)) for path in repo.rglob("*") if ".git" not in path.relative_to(repo).parts}
+
+
+def test_declare_rejects_code_contract_without_preflight() -> None:
+    with repo_fixture() as repo:
+        result = run_gate(
+            repo,
+            "declare",
+            "--intent",
+            "adjust add behavior",
+            "--scope",
+            "src/app.py",
+            "--task-type",
+            "feature",
+            "--verify",
+            "pytest tests/test_app.py",
+        )
+        assert result.returncode == 2
+        assert "requires --affected-surface" in result.stderr
+        assert "requires --authoritative-contract" in result.stderr
+        assert "requires --invariant" in result.stderr
+
+
+def test_minimal_preflight_allows_micro_bugfix_without_cargo_fields() -> None:
+
+def _advisory_added(data: dict[str, object], group: str) -> list[dict[str, object]]:
+    return list(data[group]["added"])
+
+
+def test_sensitive_input_source_only_is_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "secrets.py").write_text("import os\nTOKEN = os.environ['API_KEY']\n", encoding="utf-8")
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "warning"
+        assert findings[0]["evidence"] == "source=environment-read"
+        assert data["warnings"] == []
+        assert all(item["passed"] for item in data["checks"])
+
+
+def test_sensitive_input_source_and_sink_is_stronger_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "secrets.py").write_text(
+            "import os\nTOKEN = os.getenv('API_KEY')\nprint(TOKEN)\n", encoding="utf-8"
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+        assert "API_KEY" not in findings[0]["evidence"]
+        assert "API_KEY" not in findings[0]["message"]
+
+
+def test_sensitive_input_high_requires_same_line_or_source_identifier_flow() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "flow.py").write_text(
+            "import os\n"
+            "TOKEN = os.getenv('API_KEY')\n"
+            "print('starting')\n"
+            "status = 200\n"
+            "print(TOKEN)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+
+    with repo_fixture() as repo:
+        (repo / "src" / "unrelated.py").write_text(
+            "import os\n"
+            "print('booting')\n"
+            "TOKEN = os.getenv('API_KEY')\n"
+            "print('ready')\n"
+            "message = 'ok'\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "warning"
+        assert "sink=" not in findings[0]["evidence"]
+
+
+def test_sensitive_input_unchanged_and_broad_secret_names_do_not_hit() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "seed.py").write_text("import os\nTOKEN = os.environ['API_KEY']\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed sensitive read")
+        (repo / "src" / "seed.py").write_text(
+            "import os\nTOKEN = os.environ['API_KEY']\nVALUE = 1\n", encoding="utf-8"
+        )
+        (repo / "src" / "names.py").write_text(
+            "secret_payload = load_user_setting()\n"
+            "if os.environ:\n"
+            "    value = 1\n",
+            encoding="utf-8",
+        )
+        (repo / "src" / "headers.ts").write_text("const AUTH_HEADER = 'Authorization';\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "securityAssumptionFindings") == []
+
+
+def test_sensitive_input_test_fixtures_do_not_hit() -> None:
+    with repo_fixture() as repo:
+        (repo / "tests" / "test_secrets.py").write_text(
+            "import os\ndef test_fake_secret(tmp_path):\n"
+            "    token = os.environ['API_KEY']\n"
+            "    (tmp_path / 'out.txt').write_text(token)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "securityAssumptionFindings") == []
+
+def test_sensitive_input_text_output_is_advisory_only() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "secrets.py").write_text("import os\nTOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
+        result = run_gate(repo, "check", "--repo", str(repo))
+        assert result.returncode == 0
+        assert "Advisory findings" in result.stdout
+        assert "Warnings:\n- none" in result.stdout
+
+    with repo_fixture() as repo:
+        declare_minimal(repo)
+        status = run_gate(repo, "status")
+        contract = json.loads(status.stdout)["contract"]
+        assert contract["preflight_level"] == "minimal"
+        assert contract["max_added_lines"] == 30
+        assert contract["max_changed_lines"] == 80
+
+
+def test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight() -> None:
+    with repo_fixture() as repo:
+        result = run_gate(repo, "declare", "--intent", "edit app", "--scope", "src/app.py", "--verify", "pytest tests/test_app.py")
+        assert result.returncode == 2
+        assert "explicit --task-type" in result.stderr
+
+
+def test_global_script_path_env_updates_hook_guidance() -> None:
+    with repo_fixture() as repo:
+        script_path = "custom/$gate dir/`script`.py"
+        quoted_script_path = shlex.quote(script_path)
+        result = run_gate(
+            repo,
+            "session-start",
+            payload={"cwd": str(repo), "hook_event_name": "SessionStart"},
+            env={"LEAN_CODE_GATE_SCRIPT_PATH": script_path},
+        )
+        data = json.loads(result.stdout)
+        assert quoted_script_path in data["hookSpecificOutput"]["additionalContext"]
+
+        result = run_gate(
+            repo,
+            "pretool",
+            payload={
+                "cwd": str(repo),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "apply_patch",
+                "tool_input": {"command": "*** Begin Patch\n*** Add File: src/new.py\n+value = 1\n*** End Patch"},
+            },
+            env={"LEAN_CODE_GATE_SCRIPT_PATH": script_path},
+        )
+        data = json.loads(result.stdout)
+        assert quoted_script_path in data["reason"]
+
+
+def test_repo_root_env_keeps_state_in_target_repo_from_controller_cwd() -> None:
+    with repo_fixture() as repo:
+        with tempfile.TemporaryDirectory(prefix="gate-controller-", dir=str(repo.parent)) as ctrl:
+            controller = Path(ctrl)
+            result = run_gate(
+                controller,
+                "declare",
+                "--minimal-preflight",
+                "--intent",
+                "fix small add bug",
+                "--scope",
+                "src/app.py,tests/test_app.py",
+                "--task-type",
+                "bugfix",
+                "--verify",
+                "pytest tests/test_app.py",
+                env={"LEAN_CODE_GATE_REPO_ROOT": str(repo)},
+            )
+            assert result.returncode == 0, result.stderr
+            contract = json.loads((repo / ".agent" / "lean" / "state" / "contract.json").read_text(encoding="utf-8"))
+            assert contract["intent"] == "fix small add bug"
+            assert contract["repo_root"] == str(repo.resolve())
+            assert contract["repo_id"]
+            assert not (controller / ".agent" / "lean" / "state" / "contract.json").exists()
+
+            result = run_gate(
+                controller,
+                "status",
+                env={"LEAN_CODE_GATE_REPO_ROOT": str(repo)},
+            )
+            status = json.loads(result.stdout)
+            assert status["contract"]["intent"] == "fix small add bug"
+            assert status["runtime"]["repo_id"] == contract["repo_id"]
+            assert status["runtime"]["contract_matches_repo"] is True
+
+            result = run_gate(
+                controller,
+                "pretool",
+                payload={
+                    "cwd": str(controller),
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "apply_patch",
+                    "tool_input": {
+                        "command": "*** Begin Patch\n*** Update File: src/app.py\n@@\n-def add(a: int, b: int) -> int:\n+def add(a: int, b: int) -> int:\n*** End Patch"
+                    },
+                },
+                env={"LEAN_CODE_GATE_REPO_ROOT": str(repo)},
+            )
+            assert result.returncode == 0
+            assert result.stdout == ""
+
+
+def test_hook_resolves_nested_repo_from_changed_path_without_workdir() -> None:
+    with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
+        controller = Path(tmp)
+        git(controller, "init")
+        git(controller, "config", "user.email", "test@example.com")
+        git(controller, "config", "user.name", "Test User")
+        nested = controller / "gate"
+        init_repo_fixture(nested)
+        declare_minimal(nested)
+
+        result = run_gate(
+            controller,
+            "pretool",
+            payload={
+                "cwd": str(controller),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "apply_patch",
+                "tool_input": {
+                    "command": "*** Begin Patch\n*** Update File: gate/src/app.py\n@@\n-def add(a: int, b: int) -> int:\n+def add(a: int, b: int) -> int:\n*** End Patch"
+                },
+            },
+        )
+
+        assert result.returncode == 0, result.stdout
+        assert (nested / ".agent" / "lean" / "state" / "events.jsonl").exists()
+        assert not (controller / ".agent" / "lean" / "state" / "events.jsonl").exists()
+
+
+def test_hook_fails_closed_when_controller_target_is_ambiguous() -> None:
+    with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
+        controller = Path(tmp)
+        git(controller, "init")
+        git(controller, "config", "user.email", "test@example.com")
+        git(controller, "config", "user.name", "Test User")
+        nested = controller / "gate"
+        init_repo_fixture(nested)
+        declare_minimal(nested)
+
+        result = run_gate(
+            controller,
+            "pretool",
+            payload={
+                "cwd": str(controller),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"cmd": "git checkout -b test-branch"},
+            },
+        )
+
+        data = json.loads(result.stdout)
+        assert data["decision"] == "block"
+        assert "cannot resolve a unique target repo" in data["reason"]
+        assert "tool workdir/cwd" in data["reason"]
+        assert "No active Lean Change Contract" not in data["reason"]
+
+
+def test_stop_from_controller_checks_nested_repo_without_tool_workdir() -> None:
+    with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
+        controller = Path(tmp)
+        nested = controller / "calibration"
+        init_repo_fixture(nested)
+        declare_minimal(nested)
+
+        result = run_gate(
+            controller,
+            "pretool",
+            payload={
+                "cwd": str(controller),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": str(nested / "src" / "app.py"),
+                    "old_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                    "new_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                },
+            },
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+        result = run_gate(controller, "stop", payload={"cwd": str(controller), "hook_event_name": "Stop"})
+
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+
+def test_stop_from_controller_ignores_untargeted_dirty_nested_repo() -> None:
+    with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
+        controller = Path(tmp)
+        nested = controller / "calibration-slopscan"
+        init_repo_fixture(nested)
+        declare_minimal(nested)
+        (nested / "analysis").mkdir()
+        (nested / "analysis" / "slopscan_comparison.csv").write_text("repo,score\nx,1\n", encoding="utf-8")
+
+        result = run_gate(controller, "stop", payload={"cwd": str(controller), "hook_event_name": "Stop"})
+
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+
+def test_repo_root_env_rejects_missing_target_repo() -> None:
+    with repo_fixture() as repo:
+        missing = repo.parent / "missing-target"
+        result = run_gate(
+            repo,
+            "status",
+            env={"LEAN_CODE_GATE_REPO_ROOT": str(missing)},
+        )
+        assert result.returncode != 0
+        assert "LEAN_CODE_GATE_REPO_ROOT does not exist" in result.stderr
+        assert str(missing) in result.stderr
+
+
+def test_repo_root_env_rejects_non_git_target_repo() -> None:
+    with repo_fixture() as repo:
+        with tempfile.TemporaryDirectory(prefix="not-a-repo-", dir=str(repo.parent)) as other:
+            result = run_gate(
+                repo,
+                "status",
+                env={"LEAN_CODE_GATE_REPO_ROOT": other},
+            )
+        assert result.returncode != 0
+        assert "LEAN_CODE_GATE_REPO_ROOT is not a git repository" in result.stderr
+
+
+def test_repo_identity_does_not_persist_origin_url_credentials() -> None:
+    with repo_fixture() as repo:
+        git(repo, "remote", "add", "origin", "https://user:old-token@example.com/org/repo.git?token=old-token")
+        declare_minimal(repo)
+        path = repo / ".agent" / "lean" / "state" / "contract.json"
+        contract = json.loads(path.read_text(encoding="utf-8"))
+        assert "origin_url" not in contract
+        assert "old-token" not in path.read_text(encoding="utf-8")
+
+        git(repo, "remote", "set-url", "origin", "https://user:new-token@example.com/org/repo.git?token=new-token")
+        status = json.loads(run_gate(repo, "status").stdout)
+        assert "origin_url" not in status["runtime"]
+        assert "new-token" not in json.dumps(status)
+        assert status["runtime"]["repo_id"] == contract["repo_id"]
+        assert status["runtime"]["contract_matches_repo"] is True
+
+        events = (repo / ".agent" / "lean" / "state" / "events.jsonl").read_text(encoding="utf-8")
+        assert "old-token" not in events
+        assert "new-token" not in events
+
+
+def test_contract_for_different_repo_is_rejected() -> None:
+    with repo_fixture() as repo_a:
+        declare_minimal(repo_a)
+        with repo_fixture() as repo_b:
+            state = repo_b / ".agent" / "lean" / "state"
+            state.mkdir(parents=True)
+            shutil.copy2(repo_a / ".agent" / "lean" / "state" / "contract.json", state / "contract.json")
+
+            result = run_gate(
+                repo_b,
+                "pretool",
+                payload={
+                    "cwd": str(repo_b),
+                    "hook_event_name": "PreToolUse",
+                    "tool_name": "apply_patch",
+                    "tool_input": {
+                        "command": "*** Begin Patch\n*** Update File: src/app.py\n@@\n-def add(a: int, b: int) -> int:\n+def add(a: int, b: int) -> int:\n*** End Patch"
+                    },
+                },
+            )
+            data = json.loads(result.stdout)
+            assert data["decision"] == "block"
+            assert "belongs to repo_id" in data["reason"]
+            assert str(repo_b.resolve()) in data["reason"]
+            assert "declare ..." in data["reason"]
+
+
+def test_unstamped_contract_is_rejected_with_redeclare_hint() -> None:
+    with repo_fixture() as repo:
+        declare_minimal(repo)
+        path = repo / ".agent" / "lean" / "state" / "contract.json"
+        contract = json.loads(path.read_text(encoding="utf-8"))
+        contract.pop("repo_id")
+        path.write_text(json.dumps(contract), encoding="utf-8")
+
+        result = run_gate(
+            repo,
+            "pretool",
+            payload={
+                "cwd": str(repo),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "apply_patch",
+                "tool_input": {
+                    "command": "*** Begin Patch\n*** Update File: src/app.py\n@@\n-def add(a: int, b: int) -> int:\n+def add(a: int, b: int) -> int:\n*** End Patch"
+                },
+            },
+        )
+        data = json.loads(result.stdout)
+        assert data["decision"] == "block"
+        assert "missing repo_id" in data["reason"]
+        assert "declare ..." in data["reason"]
+
+
+def test_internal_lean_runtime_files_are_ignored_without_contract() -> None:
+    with repo_fixture() as repo:
+        state = repo / ".agent" / "lean" / "state"
+        cache = repo / ".agent" / "lean" / "__pycache__"
+        state.mkdir(parents=True)
+        cache.mkdir(parents=True)
+        (state / "contract.json").write_text("{not json", encoding="utf-8")
+        (cache / "lean_code_gate.cpython-312.pyc").write_bytes(b"runtime")
+
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop"})
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+        code, data = check_json(repo)
+        assert code == 0
+        assert data["changedFilesCount"] == 0
+        assert all(not str(path).startswith(".agent/lean/") for path in data["changedFilesSample"])
+
+        git(repo, "add", ".agent/lean/state/contract.json", ".agent/lean/__pycache__/lean_code_gate.cpython-312.pyc")
+        git(repo, "commit", "--no-gpg-sign", "-m", "runtime state")
+
+        for args in (("--base-ref", "HEAD~1"), ()):
+            code, data = check_json(repo, *args)
+            assert code == 0
+            assert data["changedFilesCount"] == 0
+            assert all(not str(path).startswith(".agent/lean/") for path in data["changedFilesSample"])
+
+
+def test_minimal_preflight_rejects_wide_budget_and_escape_hatches() -> None:
+    with repo_fixture() as repo:
+        result = run_gate(
+            repo,
+            "declare",
+            "--minimal-preflight",
+            "--intent",
+            "oversized micro fix",
+            "--scope",
+            "src/app.py",
+            "--task-type",
+            "bugfix",
+            "--verify",
+            "pytest tests/test_app.py",
+            "--max-added-lines",
+            "31",
+            "--allow-new-files",
+        )
+        assert result.returncode == 2
+        assert "max-added-lines" in result.stderr
+        assert "cannot use --allow-new-files" in result.stderr
+
+
+def test_edit_rewrite_counts_as_changed_lines() -> None:
+    with repo_fixture() as repo:
+        result = run_gate(
+            repo,
+            "declare",
+            "--intent",
+            "small edit",
+            "--scope",
+            "src/app.py",
+            "--task-type",
+            "feature",
+            "--affected-surface",
+            "add function",
+            "--authoritative-contract",
+            "edit stays within add behavior",
+            "--invariant",
+            "existing add callers remain valid",
+            "--reuse-path",
+            "src/app.py add function",
+            "--proof-plan",
+            "pytest tests/test_app.py",
+            "--risk-check",
+            "line rewrite risk",
+            "--verify",
+            "pytest tests/test_app.py",
+            "--max-changed-lines",
+            "5",
+        )
+        assert result.returncode == 0, result.stderr
+        payload = {
+            "cwd": str(repo),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(repo / "src" / "app.py"),
+                "old_string": "\n".join(f"old{i}" for i in range(10)),
+                "new_string": "\n".join(f"new{i}" for i in range(10)),
+            },
+        }
+        result = run_gate(repo, "pretool", payload=payload)
+        data = json.loads(result.stdout)
+        assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "Changes about" in data["reason"]
+
+
+def test_pretool_blocks_out_of_scope_patch() -> None:
+    with repo_fixture() as repo:
+        declare_valid(repo)
+        payload = {
+            "cwd": str(repo),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "apply_patch",
+            "tool_input": {"command": "*** Begin Patch\n*** Add File: package.json\n+{}\n*** End Patch"},
+        }
+        result = run_gate(repo, "pretool", payload=payload)
+        data = json.loads(result.stdout)
+        assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "Outside scope" in data["reason"]
+
+
+def test_pretool_blocks_fake_green_before_edit() -> None:
+    with repo_fixture() as repo:
+        declare_valid(repo)
+        payload = {
+            "cwd": str(repo),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(repo / "src" / "app.py"),
+                "old_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                "new_string": "def add(a: int, b: int) -> int:\n    # type: ignore\n    return a + b\n",
+            },
+        }
+        result = run_gate(repo, "pretool", payload=payload)
+        data = json.loads(result.stdout)
+        assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "quality escapes" in data["reason"]
+
+
+def test_stop_blocks_quality_escape_in_changed_source() -> None:
+    with repo_fixture() as repo:
+        declare_valid(repo)
+        marker = "TO" + "DO"
+        (repo / "src" / "app.py").write_text(
+            f"def add(a: int, b: int) -> int:\n    # {marker} fake future work\n    return a + b\n",
+            encoding="utf-8",
+        )
+        run_gate(
+            repo,
+            "posttool",
+            payload={"cwd": str(repo), "tool_name": "Bash", "tool_input": {"command": "pytest tests/test_app.py"}, "tool_response": {"exit_code": 0}},
+        )
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop"})
+        data = json.loads(result.stdout)
+        assert data["decision"] == "block"
+        assert "quality escapes" in data["reason"]
+
+
+def test_stop_blocks_dirty_repo_without_contract() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a - b\n", encoding="utf-8")
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop"})
+        data = json.loads(result.stdout)
+        assert data["decision"] == "block"
+        assert "no Lean Change Contract" in data["reason"]
+
+
+def test_stop_hook_active_reports_without_looping() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a - b\n", encoding="utf-8")
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop", "stop_hook_active": True})
+        data = json.loads(result.stdout)
+        assert "systemMessage" in data
+        assert "decision" not in data
+
+
+def test_stop_blocks_new_file_without_allow_new_files() -> None:
+    with repo_fixture() as repo:
+        declare_valid(repo, task_type="feature", scope="src/new.py")
+        (repo / "src" / "new.py").write_text("def helper() -> int:\n    return 1\n", encoding="utf-8")
+        run_gate(repo, "posttool", payload={"cwd": str(repo), "tool_name": "Bash", "tool_input": {"command": "pytest tests/test_app.py"}, "tool_response": {"exit_code": 0}})
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop"})
+        data = json.loads(result.stdout)
+        assert data["decision"] == "block"
+        assert "New files require --allow-new-files" in data["reason"]
+
+
+def test_failed_verify_does_not_satisfy_stop_gate() -> None:
+    with repo_fixture() as repo:
+        declare_valid(repo, task_type="feature", scope="src/app.py")
+        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a - b\n", encoding="utf-8")
+        run_gate(
+            repo,
+            "posttool",
+            payload={"cwd": str(repo), "tool_name": "Bash", "tool_input": {"command": "pytest tests/test_app.py"}, "tool_response": {"result": {"exit_code": 1}}},
+        )
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop"})
+        data = json.loads(result.stdout)
+        assert data["decision"] == "block"
+        assert "Declared verification has not passed" in data["reason"]
+
+
+def test_quality_check_detects_duplicate_added_blocks() -> None:
+    with repo_fixture() as repo:
+        duplicate = """
+def parse_user(value: str) -> str:
+    raw = value.strip()
+    normalized = raw.lower()
+    return normalized.replace(" ", "-")
+
+def parse_group(value: str) -> str:
+    raw = value.strip()
+    normalized = raw.lower()
+    return normalized.replace(" ", "-")
+
+def parse_role(value: str) -> str:
+    raw = value.strip()
+    normalized = raw.lower()
+    return normalized.replace(" ", "-")
+"""
+        (repo / "src" / "duplicate.py").write_text(duplicate, encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 2
+        assert any("duplicate added code blocks" in error for error in data["errors"])
+
+
+def test_quality_check_detects_production_type_escape_but_allows_test_any() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "unsafe.ts").write_text("export function parse(value: any) { return value }\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 2
+        assert any("quality escapes" in error for error in data["errors"])
+        (repo / "src" / "unsafe.ts").unlink()
+        (repo / "tests" / "fake.ts").write_text("const fake: any = {}\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+
+
+def test_quality_check_detects_reimplemented_existing_helper_name() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "ids.py").write_text("def normalize_user_id(value: str) -> str:\n    return value.strip().lower()\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "helper")
+        (repo / "src" / "users.py").write_text("def normalize_user_id(value: str) -> str:\n    return value.strip().lower()\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 2
+        assert "gitnexusQueries" not in data
+        assert not data["hardRules"]["noDuplication"]["passed"]
+        assert data["reuseFindings"][0]["existingFile"] == "src/ids.py"
+
+
+def test_reimplemented_dedupe_loop_fails_as_high_confidence_reuse() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "collections.py").write_text(
+            "def dedupe_items(items: list[str]) -> list[str]:\n"
+            "    seen = set()\n"
+            "    out = []\n"
+            "    for item in items:\n"
+            "        if item not in seen:\n"
+            "            seen.add(item)\n"
+            "            out.append(item)\n"
+            "    return out\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "dedupe helper")
+        (repo / "src" / "importer.py").write_text(
+            "def import_items(items: list[str]) -> list[str]:\n"
+            "    seen = set()\n"
+            "    result = []\n"
+            "    for item in items:\n"
+            "        if item not in seen:\n"
+            "            seen.add(item)\n"
+            "            result.append(item)\n"
+            "    return result\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 2
+        assert any(item["existingSymbol"] == "dedupe_items" for item in data["reuseFindings"])
+
+
+def _seed_then_modify(repo: Path, rel_path: str, seed: str, modified: str) -> None:
+    target = repo / rel_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(seed, encoding="utf-8")
+    git(repo, "add", ".")
+    git(repo, "commit", "--no-gpg-sign", "-m", f"seed {rel_path}")
+    target.write_text(modified, encoding="utf-8")
+    git(repo, "add", rel_path)
+
+
+def test_python_exact_name_duplicate_across_files_fires_on_tracked_diff() -> None:
+    # New symbol with same name as an existing one in another file. The
+    # tracked diff puts the def line into ctx.added_lines, where the bug
+    # used to suppress reuse via self-call detection. With the
+    # SYMBOL_PATTERNS-based filter, the def line is recognised as the
+    # searched symbol's own def and skipped, so the candidate stays alive.
+    with repo_fixture() as repo:
+        (repo / "src" / "parser.py").write_text(
+            "def parse_html_payload(blob):\n    return blob.decode('utf-8').strip()\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed parser")
+        _seed_then_modify(
+            repo,
+            "src/parsers.py",
+            "# placeholder\n",
+            "# placeholder\n"
+            "def parse_html_payload(blob):\n"
+            "    text = blob.decode('utf-8')\n"
+            "    return text.strip()\n",
+        )
+        code, data = check_json(repo)
+        assert code == 2, data
+        assert any(
+            f["newSymbol"] == "parse_html_payload" and f["existingSymbol"] == "parse_html_payload"
+            for f in data["reuseFindings"]
+        ), data["reuseFindings"]
+
+
+def test_go_receiver_method_duplicate_fires_on_tracked_diff() -> None:
+    # Same-name receiver methods across two .go files; SYMBOL_PATTERNS["go"]
+    # extracts the method name even when a `(r *Repo)` receiver sits between
+    # `func` and the name, so line_defines_symbol matches and the def line
+    # is skipped — the candidate fires.
+    with repo_fixture() as repo:
+        (repo / "src" / "parser.go").write_text(
+            "package main\n\ntype Repo struct{}\n\n"
+            "func (r *Repo) ParseHTMLPayload(blob []byte) string {\n"
+            "    return string(blob)\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed go parser")
+        _seed_then_modify(
+            repo,
+            "src/extra.go",
+            "package main\n\ntype Other struct{}\n",
+            "package main\n\ntype Other struct{}\n\n"
+            "func (o *Other) ParseHTMLPayload(blob []byte) string {\n"
+            "    txt := string(blob)\n"
+            "    return txt\n"
+            "}\n",
+        )
+        code, data = check_json(repo)
+        assert code == 2, data
+        assert any(
+            f.get("newSymbol") == "ParseHTMLPayload"
+            and f.get("existingSymbol") == "ParseHTMLPayload"
+            for f in data.get("reuseFindings", [])
+        ), data.get("reuseFindings")
+
+
+def test_shell_function_duplicate_fires_on_tracked_diff() -> None:
+    # SYMBOL_PATTERNS["shell"] extracts both `function name() {` and bare
+    # `name() {`. Earlier hand-rolled def regex required `def|function|...`
+    # keywords and silently missed bare shell defs, so a duplicate shell
+    # function across files passed through the gate as ok=true.
+    with repo_fixture() as repo:
+        (repo / "scripts").mkdir()
+        (repo / "scripts" / "userlib.sh").write_text(
+            "normalize_user_id() {\n    local id=$1\n    echo \"${id,,}\"\n}\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed shell lib")
+        _seed_then_modify(
+            repo,
+            "scripts/extra.sh",
+            "# placeholder\n",
+            "# placeholder\n"
+            "normalize_user_id() {\n"
+            "    local raw=$1\n"
+            "    echo \"$(echo \"$raw\" | tr 'A-Z' 'a-z')\"\n"
+            "}\n",
+        )
+        code, data = check_json(repo)
+        assert code == 2, data
+        assert any(
+            f.get("newSymbol") == "normalize_user_id"
+            and f.get("existingSymbol") == "normalize_user_id"
+            for f in data.get("reuseFindings", [])
+        ), data.get("reuseFindings")
+
+
+def test_rust_tuple_struct_duplicate_fires_on_tracked_diff() -> None:
+    # SYMBOL_PATTERNS["rust"] extracts struct/enum/trait names, and a tuple
+    # struct definition `pub struct Name(T);` self-matches the call regex
+    # `\bName\s*\(` on its own def line. Reusing SYMBOL_PATTERNS in
+    # line_defines_symbol covers this for free.
+    with repo_fixture() as repo:
+        (repo / "src" / "lib.rs").write_text(
+            "pub struct ParseHTMLPayload(pub Vec<u8>);\n\nimpl ParseHTMLPayload {\n    pub fn raw(&self) -> &[u8] { &self.0 }\n}\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed rust lib")
+        _seed_then_modify(
+            repo,
+            "src/extra.rs",
+            "// placeholder\n",
+            "// placeholder\n"
+            "pub struct ParseHTMLPayload(pub String);\n\n"
+            "impl ParseHTMLPayload {\n"
+            "    pub fn text(&self) -> &str { &self.0 }\n"
+            "}\n",
+        )
+        code, data = check_json(repo)
+        assert code == 2, data
+        assert any(
+            f.get("newSymbol") == "ParseHTMLPayload"
+            and f.get("existingSymbol") == "ParseHTMLPayload"
+            for f in data.get("reuseFindings", [])
+        ), data.get("reuseFindings")
+
+
+def test_default_arg_call_on_def_line_does_not_falsely_suppress_reuse() -> None:
+    # Precision: a def line for symbol B that calls existing symbol A in a
+    # default arg must not be treated as a "self def" of A. The filter
+    # skips only the def of the searched symbol.
+    #
+    # Names share tokens so same_behavior_name returns nonzero — making
+    # the candidate eligible to reach symbol_is_called_nearby's decision.
+    # If the def-line filter were blanket ("any def line skipped"), the
+    # default-arg call to format_currency_amount would be hidden; the
+    # detector would then see no call, treat it as reuse, and fire a false
+    # finding for format_currency_label vs format_currency_amount.
+    mod = _load_gate_module()
+    score, _reason = mod.same_behavior_name(
+        mod.SymbolDef(name="format_currency_label", path="src/wrapper.py", line=1, kind="function", language="python", tokens=mod.split_name_tokens("format_currency_label"), source="added"),
+        mod.SymbolDef(name="format_currency_amount", path="src/format.py", line=1, kind="function", language="python", tokens=mod.split_name_tokens("format_currency_amount"), source="baseline"),
+    )
+    assert score > 0, f"test precondition failed: same_behavior_name returned {score}; choose names with more shared tokens"
+
+    with repo_fixture() as repo:
+        (repo / "src" / "format.py").write_text(
+            "def format_currency_amount(amount):\n"
+            "    return f\"${amount:.2f}\"\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed format")
+        _seed_then_modify(
+            repo,
+            "src/wrapper.py",
+            "# placeholder\n",
+            "# placeholder\n"
+            "from src.format import format_currency_amount\n"
+            "def format_currency_label(amount, prefix=format_currency_amount()):\n"
+            "    return f\"Total: {prefix}\"\n",
+        )
+        code, data = check_json(repo)
+        assert code in (0, 2), data
+        assert not any(
+            f.get("newSymbol") == "format_currency_label"
+            and f.get("existingSymbol") == "format_currency_amount"
+            for f in data.get("reuseFindings", [])
+        ), data.get("reuseFindings")
+
+
+def test_reuse_detector_suppresses_generic_same_name_false_positive() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "task_a.py").write_text("def run() -> str:\n    return 'a'\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "generic helper")
+        (repo / "src" / "task_b.py").write_text("def run() -> str:\n    return 'b'\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert data["reuseFindings"] == []
+
+
+def test_reuse_detector_suppresses_same_tokens_different_domain() -> None:
+    with repo_fixture() as repo:
+        (repo / "api").mkdir()
+        (repo / "workers").mkdir()
+        (repo / "api" / "contracts.py").write_text("def parse_limit(value: str) -> int:\n    return int(value)\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "api parse")
+        (repo / "workers" / "cli.py").write_text("def parse_limit(value: str) -> str:\n    return value.split(':')[0]\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert data["reuseFindings"] == []
+
+
+def test_reuse_detector_ignores_deleted_then_recreated_helper() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "ids.py").write_text("def normalize_user_id(value: str) -> str:\n    return value.strip().lower()\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "helper")
+        (repo / "src" / "ids.py").unlink()
+        (repo / "src" / "users.py").write_text("def normalize_user_id(value: str) -> str:\n    return value.strip().lower()\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert data["reuseFindings"] == []
+
+
+def test_reuse_detector_ignores_same_name_across_languages() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "ids.py").write_text("def normalize_user_id(value: str) -> str:\n    return value.strip().lower()\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "python helper")
+        (repo / "src" / "ids.ts").write_text("export function normalize_user_id(value: string) { return value.trim().toLowerCase() }\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert data["reuseFindings"] == []
+
+
+def test_large_existing_file_small_growth_warns_but_does_not_fail_by_default() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "large.py").write_text("\n".join(f"VALUE_{i} = {i}" for i in range(1501)) + "\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "large baseline")
+        with (repo / "src" / "large.py").open("a", encoding="utf-8") as handle:
+            handle.write("EXTRA = 1\n")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert any("large source file" in warning for warning in data["warnings"])
+
+
+def test_large_existing_file_big_growth_fails() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "large.py").write_text("\n".join(f"VALUE_{i} = {i}" for i in range(1501)) + "\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "large baseline")
+        with (repo / "src" / "large.py").open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(f"EXTRA_{i} = {i}" for i in range(81)) + "\n")
+        code, data = check_json(repo)
+        assert code == 2
+        assert data["hardRules"]["codeVolume"]["passed"] is False
+
+
+_HIGH_DENSITY_TEXT = (
+    "from typing import Protocol, TypeVar, Generic\n"
+    "from abc import ABC\n"
+    "T = TypeVar('T')\n"
+    "class BaseWidget: pass\n"
+    "class WidgetFactory(Generic[T]):\n"
+    "    plugin = True\n"
+    "    pass\n"
+)
+
+
+def test_min_duplicate_count_suppresses_two_instance_hit() -> None:
+    with repo_fixture() as repo:
+        # Two identical blocks — under default reuse_min_duplicate_count=3 this
+        # MUST NOT fire; raises a calibration concern at N=2 (django pr-21152).
+        block = (
+            "def helper(x):\n"
+            "    raw = x.strip()\n"
+            "    normalized = raw.lower()\n"
+            "    return normalized.replace(\" \", \"-\")\n"
+        )
+        (repo / "src" / "twohit.py").write_text(block + "\n" + block.replace("def helper", "def helper2"), encoding="utf-8")
+        code, data = check_json(repo)
+        dup_check = next(c for c in data["checks"] if c["name"] == "no-duplicate-added-blocks")
+        assert dup_check["passed"] is True, data
+
+
+def _load_gate_module() -> object:
+    import importlib.util
+    import sys as _sys
+    spec = importlib.util.spec_from_file_location("gate_under_test", str(GATE))
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    _sys.modules["gate_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_run_process_tolerates_non_utf8_output() -> None:
+    # Regression: subprocess.Popen(text=True) decodes with strict utf-8 and
+    # crashes on non-utf-8 bytes (surfaced by gate.py running git diff over
+    # a 100-commit TypeScript window with binary patches). The fixed
+    # run_process uses errors='replace' so non-utf-8 bytes become �
+    # rather than raising UnicodeDecodeError.
+    mod = _load_gate_module()
+    with tempfile.TemporaryDirectory() as tmp:
+        result = mod.run_process(
+            ["python3", "-c", r"import sys; sys.stdout.buffer.write(b'hello \xc3\x28 world')"],
+            Path(tmp),
+        )
+        assert result.returncode == 0, result.stderr
+        # \xc3\x28 is invalid utf-8; with errors='replace' it becomes �
+        assert "hello" in result.stdout and "world" in result.stdout
+
+
+def test_high_confidence_reuse_respects_r2_r3_suppression() -> None:
+    # Regression: high_confidence_reuse used to duplicate same_behavior_name's
+    # name+token check and bypass R-2/R-3 suppression. Surfaced in calibration
+    # A5 (langchain) where __iter__/iter and _completion_with_retry/
+    # completion_with_retry were still firing despite R-3 returning (0, "").
+    mod = _load_gate_module()
+    mod._active_suppress_private_public_siblings = True
+    mod._active_framework_override_names = frozenset({"__iter__", "__next__"})
+
+    a = mod.SymbolDef("_completion_with_retry", "a.py", 1, "function", "python", ("completion", "with", "retry"), "untracked", 0)
+    b = mod.SymbolDef("completion_with_retry", "b.py", 1, "function", "python", ("completion", "with", "retry"), "untracked", 0)
+    assert mod.high_confidence_reuse(a, b) is False
+
+    # Genuine duplicate must still trip high_confidence_reuse.
+    c = mod.SymbolDef("parse_user", "a.py", 1, "function", "python", ("parse", "user"), "untracked", 0)
+    d = mod.SymbolDef("parse_user", "b.py", 1, "function", "python", ("parse", "user"), "untracked", 0)
+    assert mod.high_confidence_reuse(c, d) is True
+
+
+def test_design_re_catches_go_factory_function() -> None:
+    hits = _load_gate_module().design_hits("func NewWidgetFactory() *WidgetFactory { return nil }")
+    assert "pattern-named factory function" in hits
+
+
+def test_design_re_catches_rust_pub_type_alias() -> None:
+    hits = _load_gate_module().design_hits("pub type ScopedFieldNameState<'scope, 'a, 'py> = ScopedSetState<...>;")
+    assert "rust type-alias abstraction" in hits
+
+
+def test_pretool_blocks_high_density_abstraction_in_small_file() -> None:
+    with repo_fixture() as repo:
+        declare_valid(repo)
+        result = run_gate(repo, "pretool", payload={
+            "tool_name": "Edit", "tool_input": {"file_path": "src/app.py", "new_string": _HIGH_DENSITY_TEXT}
+        })
+        assert result.returncode == 0, result.stderr
+        assert "Possible abstraction bloat" in result.stdout
+
+
+def test_pretool_allows_low_density_abstraction_in_large_file() -> None:
+    with repo_fixture() as repo:
+        declare_valid(repo)
+        # 7 + 192 = 199 lines, density = 4/199*100 = 2.01/100, below the 3.0
+        # threshold. Since line_count >= 100, the small-file bypass is false
+        # AND density < threshold — no fire. Exercises the negative case of
+        # the density branch.
+        body = "\n".join(f"value_{i} = {i}" for i in range(192))
+        result = run_gate(repo, "pretool", payload={
+            "tool_name": "Edit", "tool_input": {"file_path": "src/app.py", "new_string": _HIGH_DENSITY_TEXT + body + "\n"}
+        })
+        assert "Possible abstraction bloat" not in result.stdout, result.stdout
+
+
+def test_pretool_blocks_at_density_threshold_in_large_file() -> None:
+    with repo_fixture() as repo:
+        declare_valid(repo)
+        # 7 + 94 = 101 lines, density = 4/101*100 = 3.96/100, >= 3.0.
+        # line_count >= 100 disables the small-file bypass, so the test
+        # actually exercises the density-firing branch (greptile P1 on PR #9
+        # caught that range(92) gave 99 lines and fired via line_count<100).
+        body = "\n".join(f"value_{i} = {i}" for i in range(94))
+        result = run_gate(repo, "pretool", payload={
+            "tool_name": "Edit", "tool_input": {"file_path": "src/app.py", "new_string": _HIGH_DENSITY_TEXT + body + "\n"}
+        })
+        assert "Possible abstraction bloat" in result.stdout, result.stdout
+
+
+def test_framework_override_names_suppress_reuse_error() -> None:
+    # Use get_queryset, which is NOT in GENERIC_SYMBOLS. Without R-2 the pair
+    # would score 100 (exact-name match) and fire a reuse error. With R-2 in
+    # the framework_override_names allowlist, same_behavior_name returns
+    # (0, "") and best_existing_match filters the candidate.
+    # Original draft used `validate`, which IS in GENERIC_SYMBOLS — that test
+    # passed even with R-2 inactive (greptile P1).
+    with repo_fixture() as repo:
+        (repo / "src" / "views1.py").write_text(
+            "class V1:\n    def get_queryset(self):\n"
+            "        return self.model.objects.filter(active=True)\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "v1")
+        (repo / "src" / "views2.py").write_text(
+            "class V2:\n    def get_queryset(self):\n"
+            "        return self.model.objects.filter(active=True)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert data["reuseFindings"] == []
+
+
+def test_private_public_sibling_pair_suppresses_reuse_error() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "admin.py").write_text(
+            "def save_formset(formset):\n    formset.save()\n", encoding="utf-8"
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "public sibling")
+        (repo / "src" / "admin.py").write_text(
+            "def save_formset(formset):\n    formset.save()\n\n"
+            "def _save_formset(formset):\n    formset.save()\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert data["reuseFindings"] == []
+
+
+def test_excluded_path_globs_skip_generated_sdk_files() -> None:
+    with repo_fixture() as repo:
+        (repo / "clients" / "client-test" / "src" / "commands").mkdir(parents=True)
+        big = "\n".join(f"export const CMD_{i} = {{}};" for i in range(900))
+        (repo / "clients" / "client-test" / "src" / "commands" / "BigCmd.ts").write_text(big + "\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert all("clients/client-test/src/commands/BigCmd.ts" not in error for error in data["errors"])
+
+
+def test_excluded_path_globs_match_first_component_path() -> None:
+    # Regression: fnmatch treats ** as a single *, so "**/migrations/**" must
+    # also match a path whose FIRST component is the excluded directory
+    # (e.g. "migrations/0001_initial.py"), not just nested cases.
+    with repo_fixture() as repo:
+        (repo / "migrations").mkdir()
+        big = "\n".join(f"OP_{i} = None" for i in range(900))
+        (repo / "migrations" / "0001_initial.py").write_text(big + "\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert all("migrations/0001_initial.py" not in error for error in data["errors"])
+
+
+def test_excluded_path_globs_can_be_overridden_to_empty() -> None:
+    with repo_fixture() as repo:
+        (repo / ".agent" / "lean" / "policy.json").write_text(
+            json.dumps({"excluded_path_globs": []}), encoding="utf-8"
+        )
+        (repo / "clients" / "client-test" / "src" / "commands").mkdir(parents=True)
+        big = "\n".join(f"export const CMD_{i} = {{}};" for i in range(900))
+        (repo / "clients" / "client-test" / "src" / "commands" / "BigCmd.ts").write_text(big + "\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 2, data
+        assert any("clients/client-test/src/commands/BigCmd.ts" in error for error in data["errors"])
+
+
+def test_gate_check_creates_no_repo_artifacts() -> None:
+    with repo_fixture() as repo:
+        before = snapshot_paths(repo)
+        code, data = check_json(repo)
+        after = snapshot_paths(repo)
+        assert code == 0
+        assert data["ok"] is True
+        assert after == before
+
+
+TESTS = [
+    test_declare_rejects_code_contract_without_preflight,
+    test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
+    test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,
+    test_global_script_path_env_updates_hook_guidance,
+    test_repo_root_env_keeps_state_in_target_repo_from_controller_cwd,
+    test_hook_resolves_nested_repo_from_changed_path_without_workdir,
+    test_hook_fails_closed_when_controller_target_is_ambiguous,
+    test_stop_from_controller_checks_nested_repo_without_tool_workdir,
+    test_stop_from_controller_ignores_untargeted_dirty_nested_repo,
+    test_repo_root_env_rejects_missing_target_repo,
+    test_repo_root_env_rejects_non_git_target_repo,
+    test_repo_identity_does_not_persist_origin_url_credentials,
+    test_contract_for_different_repo_is_rejected,
+    test_unstamped_contract_is_rejected_with_redeclare_hint,
+    test_internal_lean_runtime_files_are_ignored_without_contract,
+    test_minimal_preflight_rejects_wide_budget_and_escape_hatches,
+    test_edit_rewrite_counts_as_changed_lines,
+    test_pretool_blocks_out_of_scope_patch,
+    test_pretool_blocks_fake_green_before_edit,
+    test_stop_blocks_quality_escape_in_changed_source,
+    test_stop_blocks_dirty_repo_without_contract,
+    test_stop_hook_active_reports_without_looping,
+    test_sensitive_input_source_only_is_advisory,
+    test_sensitive_input_source_and_sink_is_stronger_advisory,
+    test_sensitive_input_high_requires_same_line_or_source_identifier_flow,
+    test_sensitive_input_unchanged_and_broad_secret_names_do_not_hit,
+    test_sensitive_input_test_fixtures_do_not_hit,
+    test_sensitive_input_text_output_is_advisory_only,
+    test_stop_blocks_new_file_without_allow_new_files,
+    test_failed_verify_does_not_satisfy_stop_gate,
+    test_quality_check_detects_duplicate_added_blocks,
+    test_quality_check_detects_production_type_escape_but_allows_test_any,
+    test_quality_check_detects_reimplemented_existing_helper_name,
+    test_reimplemented_dedupe_loop_fails_as_high_confidence_reuse,
+    test_python_exact_name_duplicate_across_files_fires_on_tracked_diff,
+    test_go_receiver_method_duplicate_fires_on_tracked_diff,
+    test_shell_function_duplicate_fires_on_tracked_diff,
+    test_rust_tuple_struct_duplicate_fires_on_tracked_diff,
+    test_default_arg_call_on_def_line_does_not_falsely_suppress_reuse,
+    test_reuse_detector_suppresses_generic_same_name_false_positive,
+    test_reuse_detector_suppresses_same_tokens_different_domain,
+    test_reuse_detector_ignores_deleted_then_recreated_helper,
+    test_reuse_detector_ignores_same_name_across_languages,
+    test_large_existing_file_small_growth_warns_but_does_not_fail_by_default,
+    test_large_existing_file_big_growth_fails,
+    test_min_duplicate_count_suppresses_two_instance_hit,
+    test_run_process_tolerates_non_utf8_output,
+    test_high_confidence_reuse_respects_r2_r3_suppression,
+    test_design_re_catches_go_factory_function,
+    test_design_re_catches_rust_pub_type_alias,
+    test_pretool_blocks_high_density_abstraction_in_small_file,
+    test_pretool_allows_low_density_abstraction_in_large_file,
+    test_pretool_blocks_at_density_threshold_in_large_file,
+    test_framework_override_names_suppress_reuse_error,
+    test_private_public_sibling_pair_suppresses_reuse_error,
+    test_excluded_path_globs_skip_generated_sdk_files,
+    test_excluded_path_globs_match_first_component_path,
+    test_excluded_path_globs_can_be_overridden_to_empty,
+    test_gate_check_creates_no_repo_artifacts,
+]
+
+
+if __name__ == "__main__":
+    for test in TESTS:
+        test()
+        print(f"ok {test.__name__}")
+    print(f"passed {len(TESTS)} lean-code-gate tests")


### PR DESCRIPTION
# 01_PR1_sensitive_input

Problem:
Added production code can read credential-bearing data and leak or persist it.

Named failure mode:
sensitive input read with optional source-to-sink evidence in touched production source

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, lean-code skill docs, supplied V1.3 plan, and reward spec scope where applicable. Supplied archive did not contain calibration/HANDOVER.md or calibration/analysis/COHORT_TABLE.md, so no current-corpus rerun is claimed.

Exact scope:
Production source added lines only. Source-only warning; high only for same-line sink or identifier flow to a later sink line.

Existing surfaces touched:
P0 securityAssumptionFindings; GateContext.added_lines_with_untracked(); is_production_source_path(); risk_check docs.

Files changed:
.agent/lean/lean_code_gate.py, .agents/skills/lean-code/SKILL.md, .claude/skills/lean-code/SKILL.md, METHODOLOGY.md, tests/test_lean_code_gate.py

Prerequisites:
00_PR0_P0_advisory_surface

Net lean_code_gate.py lines added:
+103 / -1

Total patch size:
+220 / -1

Helpers reused:
is_production_source_path(), language/path filters, advisory_finding()

Helpers added:
first_rule_match(), scan_sensitive_input(), scan_sensitive_input_lines(), assigned_identifier(), sensitive_sink_for_source()

Why existing helpers were insufficient:
Existing quality escape scanners intentionally catch suppressions, not sensitive input reads or source/sink evidence.

Deletion/consolidation attempted:
Dropped broad cache/state/status/error/message/response sinks and broad auth-string matching.

Chosen path:
Small source/sink regex set with identifier-based high severity only.

Rejected simpler paths:
Credential regex catalog, taint engine, test-file coverage, symmetric proximity high severity.

Compatibility impact:
Advisory-only JSON. No legacy warnings or blockers.

Verification:
Sensitive source, same-line/identifier-flow high severity, broad non-hit, test fixture non-hit, text-output advisory-only. See VERIFY.log and verify_after_main_merge.log.

Calibration rule:
Warning-only fixtures now. Promotion requires current-corpus attribution below duplicate-block FP baseline.

Rollback path:
Remove constants, helper calls, P0 population, docs, and tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification and methodology documentation for code quality standards and workflow requirements.

* **Tests**
  * Added comprehensive test suite for quality gate validation across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->