### PR TITLE
P0: add advisory finding surface

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -373,6 +373,8 @@ GENERIC_MATCH_TOKENS = {
     "wait",
     "with",
 }
+ADVISORY_GROUP_NAMES = ("securityAssumptionFindings", "slopShapeFindings", "verificationShapeFindings")
+ADVISORY_BUCKET_NAMES = ("added", "resolved", "worsened", "improved")
 RISKY_BLOCK_RULE = re.compile(
     r"\b(?:for|while|map|filter|reduce|retry|fetch|read|write|parse|normalize|validate|format|resolve|dedupe|deduplicate)\b",
     re.I,
@@ -1730,6 +1732,11 @@ def apply_active_policy(active_policy: dict[str, object]) -> None:
     _active_min_duplicate_count = max(2, int(active_policy.get("reuse_min_duplicate_count") or 2))
 
 
+
+def empty_advisory_groups() -> dict[str, dict[str, list[dict[str, object]]]]:
+    return {name: {bucket: [] for bucket in ADVISORY_BUCKET_NAMES} for name in ADVISORY_GROUP_NAMES}
+
+
 def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -> dict[str, object]:
     active_policy = policy(repo)
     apply_active_policy(active_policy)
@@ -1778,6 +1785,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
         "reuseFindings": [finding.as_dict() for finding in reuse_findings],
         "qualityEscapeLocations": list(quality_escapes),
         "duplicateBlockCandidates": [{"count": int(d["count"]), "files": list(d["files"])} for d in duplicates_all],
+        **empty_advisory_groups(),
     }
 
 

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -133,6 +133,27 @@ def snapshot_paths(repo: Path) -> set[str]:
     return {str(path.relative_to(repo)) for path in repo.rglob("*") if ".git" not in path.relative_to(repo).parts}
 
 
+
+def test_p0_advisory_groups_are_empty_and_compatible() -> None:
+    with repo_fixture() as repo:
+        code, data = check_json(repo)
+        assert code == 0
+        for name in ("securityAssumptionFindings", "slopShapeFindings", "verificationShapeFindings"):
+            assert data[name] == {"added": [], "resolved": [], "worsened": [], "improved": []}
+        assert data["ok"] is True
+        assert data["warnings"] == []
+        assert all(item["passed"] for item in data["checks"])
+        assert all(item["passed"] for item in data["hardRules"].values())
+
+        text_result = run_gate(repo, "check", "--repo", str(repo))
+        assert text_result.returncode == 0
+        assert "Advisory findings" not in text_result.stdout
+
+        promoted = run_gate(repo, "check", "--repo", str(repo), "--fail-on-warnings", "--json")
+        promoted_data = json.loads(promoted.stdout)
+        assert promoted.returncode == 0
+        assert promoted_data["errors"] == []
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1186,6 +1207,7 @@ def test_gate_check_creates_no_repo_artifacts() -> None:
 
 
 TESTS = [
+    test_p0_advisory_groups_are_empty_and_compatible,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,


### PR DESCRIPTION
# 00_PR0_P0_advisory_surface

Problem:
P1-P5 needed one additive advisory output surface instead of inventing separate warning plumbing.

Named failure mode:
detectors accidentally promote advisory findings or fork incompatible JSON shapes

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, lean-code skill docs, supplied V1.3 plan, and reward spec scope where applicable. Supplied archive did not contain calibration/HANDOVER.md or calibration/analysis/COHORT_TABLE.md, so no current-corpus rerun is claimed.

Exact scope:
Add empty advisory JSON groups only, with compatibility coverage. No detectors.

Existing surfaces touched:
run_quality_gate(), empty_advisory_groups(), tests/test_lean_code_gate.py

Files changed:
.agent/lean/lean_code_gate.py, tests/test_lean_code_gate.py

Prerequisites:
none

Net lean_code_gate.py lines added:
+8 / -0

Total patch size:
+30 / -0

Helpers reused:
run_quality_gate(), quality_checks(), hard_rules(), format_quality_text()

Helpers added:
empty_advisory_groups()

Why existing helpers were insufficient:
No existing helper returned the three advisory families with the four required buckets.

Deletion/consolidation attempted:
Kept P0 to one helper and one spread; no formatter or dataclass added.

Chosen path:
Plain additive dicts in run_quality_gate().

Rejected simpler paths:
Dataclass, formatter framework, status/declare wiring, or legacy warnings integration.

Compatibility impact:
Old JSON fields remain; empty groups do not affect text, ok, warnings, checks, hardRules, or fail-on-warnings.

Verification:
test_p0_advisory_groups_are_empty_and_compatible; py_compile. See VERIFY.log and verify_after_main_merge.log.

Calibration rule:
None. Infrastructure only.

Rollback path:
Keep released field names if possible; otherwise revert helper, spread, and compatibility test before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for advisory group findings in quality gate checks, ensuring consistent handling of advisory fields and proper reporting structure.

* **Chores**
  * Implemented telemetry scaffolding infrastructure to provide consistent advisory field structures in quality gate outputs, enabling downstream consumers to receive uniform data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->