### PR TITLE
P1: add sensitive input advisories

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1322,14 +1322,13 @@ def scan_sensitive_input_lines(path: str, added_lines: list[tuple[int, str]], si
 
 
 def sensitive_sink_for_source(line_no: int, text: str, sinks: list[tuple[int, str, str]]) -> str:
-    same_line = first_rule_match(text, SENSITIVE_SINK_RULES)
-    if same_line:
-        return same_line
+    source_match = next((match for pattern, _label in SENSITIVE_SOURCE_RULES if (match := pattern.search(text))), None)
+    same_line = next(((match, label) for pattern, label in SENSITIVE_SINK_RULES if (match := pattern.search(text))), None)
     identifier = assigned_identifier(text)
-    if not identifier:
-        return ""
-    use_re = re.compile(rf"\b{re.escape(identifier)}\b")
-    return next((label for sink_line, sink_text, label in sinks if label and 0 < sink_line - line_no <= 8 and use_re.search(sink_text)), "")
+    use_re = re.compile(rf"\b{re.escape(identifier)}\b") if identifier else None
+    if source_match and same_line and ((use_re and use_re.search(text[source_match.end():])) or (use_re is None and same_line[1] != "persistence" and same_line[0].start() <= source_match.start())):
+        return same_line[1]
+    return next((label for sink_line, sink_text, label in sinks if use_re and label and 0 < sink_line - line_no <= 8 and use_re.search(sink_text)), "")
 
 
 def assigned_identifier(text: str) -> str:

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -307,6 +307,20 @@ EMPTY_CATCH_RULES = [
     re.compile(r"except\s+Exception\s*:\s*\n\s*pass\b", re.S),
     re.compile(r"except\s*:\s*\n\s*pass\b", re.S),
 ]
+SENSITIVE_SOURCE_RULES = [
+    (re.compile(r"\b(?:os\.getenv|os\.environ\s*(?:\.get|\[)|process\.env\s*(?:\.|\[)|Deno\.env\.get|std::env::var|os\.Getenv|getenv\s*\()"), "environment-read"),
+    (re.compile(r"\bgit\s+(?:remote\s+get-url|config\s+--get\s+remote\.)"), "git-remote-url-read"),
+    (re.compile(r"(?:^|[/\\])(?:\.netrc|\.ssh|\.aws)(?:[/\\]|$)|\b(?:id_rsa|id_ed25519|known_hosts)\b"), "credential-file-read"),
+    (re.compile(r"\b(?:keyring\.|keytar\.|SecretStorage|security\s+find-generic-password)"), "keyring-read"),
+    (re.compile(r"""(?:\b(?:req|request)\.headers|\bheaders)\s*(?:\.get\s*\(\s*['"](?:authorization|cookie|set-cookie)['"]|\[\s*['"](?:Authorization|Cookie|Set-Cookie)['"]\s*\])|\bgetHeader\s*\(\s*['"](?:Authorization|Cookie|Set-Cookie)['"]""", re.I), "auth-header-read"),
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private-key-material"),
+]
+SENSITIVE_SINK_RULES = [
+    (re.compile(r"\b(?:console\.(?:log|error|warn)|print|fmt\.Print(?:f|ln)?|println!|eprintln!|logger?\.|log\.)\s*\("), "log-or-console"),
+    (re.compile(r"\b(?:JSON\.stringify|json\.dumps|pickle\.dump|yaml\.dump|serialize|snapshot)\b|\b(?:telemetry|metrics)\.(?:track|emit|record|log)\s*\("), "serialization-or-telemetry"),
+    (re.compile(r"""\b(?:write_text|write_bytes|writeFile|appendFile|fs\.(?:writeFile|appendFile)|open\s*\([^)]*['"]w)\b"""), "persistence"),
+]
+SENSITIVE_IDENTIFIER_RE = re.compile(r"^(?:\s*(?:const|let|var)\s+)?([A-Za-z_$][\w$]*)\s*(?::=|=)")
 GENERIC_SYMBOLS = {
     "app",
     "config",
@@ -1247,6 +1261,62 @@ def line_hits(path: str, lines: list[tuple[int, str]], rules: list[re.Pattern[st
     return hits
 
 
+
+def advisory_finding(rule: str, family: str, path: str, line: int, severity: str, message: str, evidence: str) -> dict[str, object]:
+    return {
+        "rule": rule,
+        "family": family,
+        "path": path,
+        "line": line,
+        "severity": severity,
+        "message": message,
+        "evidence": evidence,
+    }
+
+
+def first_rule_match(text: str, rules: list[tuple[re.Pattern[str], str]]) -> str:
+    return next((label for pattern, label in rules if pattern.search(text)), "")
+
+
+def scan_sensitive_input(ctx: GateContext) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items():
+        if is_production_source_path(rel_path):
+            findings.extend(scan_sensitive_input_lines(rel_path, lines))
+    return findings
+
+
+def scan_sensitive_input_lines(path: str, lines: list[tuple[int, str]]) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    sinks = [(line_no, text, first_rule_match(text, SENSITIVE_SINK_RULES)) for line_no, text in lines]
+    for line_no, text in lines:
+        source = first_rule_match(text, SENSITIVE_SOURCE_RULES)
+        if not source:
+            continue
+        sink = sensitive_sink_for_source(line_no, text, sinks)
+        severity = "high" if sink else "warning"
+        evidence = f"source={source}" + (f"; sink={sink}" if sink else "")
+        message = "added code reads sensitive input" + (" and exposes or persists it nearby" if sink else "; keep it out of logs, persistence, and telemetry")
+        findings.append(advisory_finding("sensitive-input", "security", path, line_no, severity, message, evidence))
+    return findings
+
+
+def sensitive_sink_for_source(line_no: int, text: str, sinks: list[tuple[int, str, str]]) -> str:
+    same_line = first_rule_match(text, SENSITIVE_SINK_RULES)
+    if same_line:
+        return same_line
+    identifier = assigned_identifier(text)
+    if not identifier:
+        return ""
+    use_re = re.compile(rf"\b{re.escape(identifier)}\b")
+    return next((label for sink_line, sink_text, label in sinks if label and 0 < sink_line - line_no <= 8 and use_re.search(sink_text)), "")
+
+
+def assigned_identifier(text: str) -> str:
+    found = SENSITIVE_IDENTIFIER_RE.search(text)
+    return found.group(1) if found else ""
+
+
 def multiline_hits(path: str, text: str) -> list[str]:
     return [f"{path}:{text[: match.start()].count(chr(10)) + 1}" for rule in EMPTY_CATCH_RULES for match in rule.finditer(text)]
 
@@ -1752,6 +1822,8 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     reuse_findings = detect_reuse_issues(ctx, active_policy)
     reuse_errors = [finding for finding in reuse_findings if finding.severity == "error"]
     reuse_warnings = [finding for finding in reuse_findings if finding.severity == "warning"]
+    advisory_groups = empty_advisory_groups()
+    advisory_groups["securityAssumptionFindings"]["added"].extend(scan_sensitive_input(ctx))
 
     if conflict_files:
         errors.append(f"merge conflict markers found in {len(conflict_files)} file(s)")
@@ -1785,7 +1857,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
         "reuseFindings": [finding.as_dict() for finding in reuse_findings],
         "qualityEscapeLocations": list(quality_escapes),
         "duplicateBlockCandidates": [{"count": int(d["count"]), "files": list(d["files"])} for d in duplicates_all],
-        **empty_advisory_groups(),
+        **advisory_groups,
     }
 
 
@@ -1835,6 +1907,29 @@ def hard_rules(checks: list[dict[str, object]]) -> dict[str, dict[str, object]]:
     }
 
 
+def advisory_findings(result: dict[str, object]) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for group_name in ADVISORY_GROUP_NAMES:
+        group = result.get(group_name)
+        if not isinstance(group, dict):
+            continue
+        for bucket in ADVISORY_BUCKET_NAMES:
+            values = group.get(bucket)
+            if isinstance(values, list):
+                findings.extend(item for item in values if isinstance(item, dict))
+    return findings
+
+
+def format_advisory_sample(finding: dict[str, object]) -> str:
+    path = str(finding.get("path") or "unknown")
+    line = int(finding.get("line") or 0)
+    severity = str(finding.get("severity") or "warning")
+    rule = str(finding.get("rule") or "advisory")
+    message = str(finding.get("message") or "advisory finding")
+    location = f"{path}:{line}" if line else path
+    return f"- {severity} {rule} at {location}: {message}"
+
+
 def format_quality_text(result: dict[str, object]) -> str:
     lines = [
         "Lean Code Quality Gate",
@@ -1852,6 +1947,13 @@ def format_quality_text(result: dict[str, object]) -> str:
     lines.append("")
     lines.append("Warnings:")
     lines.extend([f"- {warning}" for warning in result["warnings"]] if result["warnings"] else ["- none"])
+    findings = advisory_findings(result)
+    if findings:
+        lines.append("")
+        lines.append("Advisory findings:")
+        lines.extend(format_advisory_sample(finding) for finding in findings[:8])
+        if len(findings) > 8:
+            lines.append(f"- ... {len(findings) - 8} more advisory finding(s)")
     return "\n".join(lines)
 
 

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -307,11 +307,12 @@ EMPTY_CATCH_RULES = [
     re.compile(r"except\s+Exception\s*:\s*\n\s*pass\b", re.S),
     re.compile(r"except\s*:\s*\n\s*pass\b", re.S),
 ]
+CREDENTIAL_PATH_RE_FRAGMENT = r"(?:\.netrc|\.ssh|\.aws|id_rsa|id_ed25519|known_hosts)"
 SENSITIVE_SOURCE_RULES = [
     (re.compile(r"\b(?:os\.getenv|os\.environ\s*(?:\.get|\[)|process\.env\s*(?:\.|\[)|Deno\.env\.get|std::env::var|os\.Getenv|getenv\s*\()"), "environment-read"),
     (re.compile(r"\bgit\s+(?:remote\s+get-url|config\s+--get\s+remote\.)"), "git-remote-url-read"),
     (re.compile(r"""\b(?:subprocess\.(?:run|Popen|check_output|check_call)|child_process\.(?:execFile|spawn)|execFile|spawn|ProcessBuilder)\s*\(\s*\[?\s*['"]git['"]\s*,\s*(?:\[\s*)?['"]remote['"]\s*,\s*['"]get-url['"]"""), "git-remote-url-read"),
-    (re.compile(r"(?:^|[/\\])(?:\.netrc|\.ssh|\.aws)(?:[/\\]|$)|\b(?:id_rsa|id_ed25519|known_hosts)\b"), "credential-file-read"),
+    (re.compile(rf"""\b(?:open|io\.open|os\.open|(?:fs\.)?readFile(?:Sync)?)\s*\([^)\n]*{CREDENTIAL_PATH_RE_FRAGMENT}|\b(?:Path|pathlib\.Path)\s*\([^)\n]*{CREDENTIAL_PATH_RE_FRAGMENT}[^)\n]*\)\s*\.\s*(?:open|read_text|read_bytes)\s*\("""), "credential-file-read"),
     (re.compile(r"\b(?:keyring\.|keytar\.|SecretStorage|security\s+find-generic-password)"), "keyring-read"),
     (re.compile(r"""(?:\b(?:req|request)\.headers|\bheaders)\s*(?:\.get\s*\(\s*['"](?:authorization|cookie|set-cookie)['"]|\[\s*['"](?:Authorization|Cookie|Set-Cookie)['"]\s*\])|\bgetHeader\s*\(\s*['"](?:Authorization|Cookie|Set-Cookie)['"]""", re.I), "auth-header-read"),
     (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private-key-material"),
@@ -1297,16 +1298,18 @@ def first_rule_match(text: str, rules: list[tuple[re.Pattern[str], str]]) -> str
 
 def scan_sensitive_input(ctx: GateContext) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
-    for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items():
+    for rel_path, added_lines in ctx.added_lines_with_untracked(production_only=True).items():
         if is_production_source_path(rel_path):
-            findings.extend(scan_sensitive_input_lines(rel_path, lines))
+            text = read_file(ctx.repo / rel_path)
+            sink_lines = list(enumerate(text.splitlines(), 1)) if text is not None else added_lines
+            findings.extend(scan_sensitive_input_lines(rel_path, added_lines, sink_lines))
     return findings
 
 
-def scan_sensitive_input_lines(path: str, lines: list[tuple[int, str]]) -> list[dict[str, object]]:
+def scan_sensitive_input_lines(path: str, added_lines: list[tuple[int, str]], sink_lines: list[tuple[int, str]]) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
-    sinks = [(line_no, text, first_rule_match(text, SENSITIVE_SINK_RULES)) for line_no, text in lines]
-    for line_no, text in lines:
+    sinks = [(line_no, text, first_rule_match(text, SENSITIVE_SINK_RULES)) for line_no, text in sink_lines]
+    for line_no, text in added_lines:
         source = first_rule_match(text, SENSITIVE_SOURCE_RULES)
         if not source:
             continue

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -317,7 +317,17 @@ SENSITIVE_SOURCE_RULES = [
     (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private-key-material"),
 ]
 SENSITIVE_SINK_RULES = [
-    (re.compile(r"\b(?:console\.(?:log|error|warn)|print|fmt\.Print(?:f|ln)?|println!|eprintln!|logger?\.|log\.)\s*\("), "log-or-console"),
+    (
+        re.compile(
+            r"\b(?:console\.(?:log|error|warn|info|debug|trace)"
+            r"|print"
+            r"|fmt\.Print(?:f|ln)?"
+            r"|println!|eprintln!"
+            r"|(?:logging|logger|log)\.[A-Za-z_][\w]*"
+            r")\s*\("
+        ),
+        "log-or-console",
+    ),
     (re.compile(r"\b(?:JSON\.stringify|json\.dumps|pickle\.dump|yaml\.dump|serialize|snapshot)\b|\b(?:telemetry|metrics)\.(?:track|emit|record|log)\s*\("), "serialization-or-telemetry"),
     (re.compile(r"""\b(?:write_text|write_bytes|writeFile|appendFile|fs\.(?:writeFile|appendFile)|open\s*\([^)]*['"]w)\b"""), "persistence"),
 ]

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -310,6 +310,7 @@ EMPTY_CATCH_RULES = [
 SENSITIVE_SOURCE_RULES = [
     (re.compile(r"\b(?:os\.getenv|os\.environ\s*(?:\.get|\[)|process\.env\s*(?:\.|\[)|Deno\.env\.get|std::env::var|os\.Getenv|getenv\s*\()"), "environment-read"),
     (re.compile(r"\bgit\s+(?:remote\s+get-url|config\s+--get\s+remote\.)"), "git-remote-url-read"),
+    (re.compile(r"""\b(?:subprocess\.(?:run|Popen|check_output|check_call)|child_process\.(?:execFile|spawn)|execFile|spawn|ProcessBuilder)\s*\(\s*\[?\s*['"]git['"]\s*,\s*(?:\[\s*)?['"]remote['"]\s*,\s*['"]get-url['"]"""), "git-remote-url-read"),
     (re.compile(r"(?:^|[/\\])(?:\.netrc|\.ssh|\.aws)(?:[/\\]|$)|\b(?:id_rsa|id_ed25519|known_hosts)\b"), "credential-file-read"),
     (re.compile(r"\b(?:keyring\.|keytar\.|SecretStorage|security\s+find-generic-password)"), "keyring-read"),
     (re.compile(r"""(?:\b(?:req|request)\.headers|\bheaders)\s*(?:\.get\s*\(\s*['"](?:authorization|cookie|set-cookie)['"]|\[\s*['"](?:Authorization|Cookie|Set-Cookie)['"]\s*\])|\bgetHeader\s*\(\s*['"](?:Authorization|Cookie|Set-Cookie)['"]""", re.I), "auth-header-read"),
@@ -320,7 +321,13 @@ SENSITIVE_SINK_RULES = [
     (re.compile(r"\b(?:JSON\.stringify|json\.dumps|pickle\.dump|yaml\.dump|serialize|snapshot)\b|\b(?:telemetry|metrics)\.(?:track|emit|record|log)\s*\("), "serialization-or-telemetry"),
     (re.compile(r"""\b(?:write_text|write_bytes|writeFile|appendFile|fs\.(?:writeFile|appendFile)|open\s*\([^)]*['"]w)\b"""), "persistence"),
 ]
-SENSITIVE_IDENTIFIER_RE = re.compile(r"^(?:\s*(?:const|let|var)\s+)?([A-Za-z_$][\w$]*)\s*(?::=|=)")
+SENSITIVE_IDENTIFIER_RE = re.compile(
+    r"^\s*"
+    r"(?:(?:const|let|var)\s+)?"
+    r"([A-Za-z_$][\w$]*)"
+    r"(?:\s*:\s*[^=]+?)?"
+    r"\s*(?::=|=(?!=))"
+)
 GENERIC_SYMBOLS = {
     "app",
     "config",

--- a/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
@@ -111,6 +111,7 @@ Escape hatches need evidence:
 - No new package if standard library or an existing package solves the problem cleanly.
 - No second package manager or second lockfile.
 - No broad error handling for impossible scenarios.
+- Treat reads from environment, credential files, keyrings, auth/cookie headers, private keys, or git remote URLs as sensitive input; name the risk in `--risk-check` and never log, serialize, cache, snapshot, or emit the values.
 - No fake-green patterns: `|| true`, blanket suppressions, broad catch/pass, empty catch, `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `# type: ignore`, `# noqa`.
 - No `TODO`, `FIXME`, `HACK`, placeholders, dummy adapters, temporary bypasses, or unfinished stubs in changed source.
 - Delete only orphans created by your own change.

--- a/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
@@ -111,6 +111,7 @@ Escape hatches need evidence:
 - No new package if standard library or an existing package solves the problem cleanly.
 - No second package manager or second lockfile.
 - No broad error handling for impossible scenarios.
+- Treat reads from environment, credential files, keyrings, auth/cookie headers, private keys, or git remote URLs as sensitive input; name the risk in `--risk-check` and never log, serialize, cache, snapshot, or emit the values.
 - No fake-green patterns: `|| true`, blanket suppressions, broad catch/pass, empty catch, `eslint-disable`, `@ts-ignore`, `@ts-expect-error`, `# type: ignore`, `# noqa`.
 - No `TODO`, `FIXME`, `HACK`, placeholders, dummy adapters, temporary bypasses, or unfinished stubs in changed source.
 - Delete only orphans created by your own change.

--- a/lean-code-gate-v3/METHODOLOGY.md
+++ b/lean-code-gate-v3/METHODOLOGY.md
@@ -84,6 +84,8 @@ The final quality gate inspects the changed source scope and fails on:
 - high-confidence helper or loop reimplementation
 - risk-calibrated bloat
 
+The advisory surface also reports sensitive-input reads when changed code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value.
+
 Warnings are emitted for moderate bloat and weaker reuse signals. Projects can promote warnings to failures in `.agent/lean/policy.json`.
 
 ## Operating guidance

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -207,10 +207,7 @@ def test_sensitive_input_high_requires_same_line_or_source_identifier_flow() -> 
     with repo_fixture() as repo:
         (repo / "src" / "unrelated.py").write_text(
             "import os\n"
-            "print('booting')\n"
-            "TOKEN = os.getenv('API_KEY')\n"
-            "print('ready')\n"
-            "message = 'ok'\n",
+            "TOKEN = os.getenv('API_KEY'); print('ready')\n",
             encoding="utf-8",
         )
         code, data = check_json(repo)
@@ -263,6 +260,16 @@ def test_sensitive_input_credential_paths_require_read_call() -> None:
         code, data = check_json(repo)
         assert code == 0, data
         assert _advisory_added(data, "securityAssumptionFindings") == []
+        (repo / "src" / "paths.py").write_text(
+            "open('.ssh/id_ed25519', 'w').write(key)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "warning"
+        assert "sink=" not in findings[0]["evidence"]
         (repo / "src" / "paths.py").write_text(
             "KEY = open('.ssh/id_ed25519').read()\n",
             encoding="utf-8",
@@ -401,8 +408,7 @@ def test_sensitive_input_python_logger_method_call_escalates() -> None:
 def test_sensitive_input_console_info_method_call_escalates() -> None:
     with repo_fixture() as repo:
         (repo / "src" / "client.ts").write_text(
-            "const TOKEN = process.env.API_KEY;\n"
-            "console.info(TOKEN);\n",
+            "const TOKEN = process.env.API_KEY; console.info(TOKEN);\n",
             encoding="utf-8",
         )
         code, data = check_json(repo)

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -154,6 +154,113 @@ def test_p0_advisory_groups_are_empty_and_compatible() -> None:
         assert promoted.returncode == 0
         assert promoted_data["errors"] == []
 
+
+def _advisory_added(data: dict[str, object], group: str) -> list[dict[str, object]]:
+    return list(data[group]["added"])
+
+
+def test_sensitive_input_source_only_is_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "secrets.py").write_text("import os\nTOKEN = os.environ['API_KEY']\n", encoding="utf-8")
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "warning"
+        assert findings[0]["evidence"] == "source=environment-read"
+        assert data["warnings"] == []
+        assert all(item["passed"] for item in data["checks"])
+
+
+def test_sensitive_input_source_and_sink_is_stronger_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "secrets.py").write_text(
+            "import os\nTOKEN = os.getenv('API_KEY')\nprint(TOKEN)\n", encoding="utf-8"
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+        assert "API_KEY" not in findings[0]["evidence"]
+        assert "API_KEY" not in findings[0]["message"]
+
+
+def test_sensitive_input_high_requires_same_line_or_source_identifier_flow() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "flow.py").write_text(
+            "import os\n"
+            "TOKEN = os.getenv('API_KEY')\n"
+            "print('starting')\n"
+            "status = 200\n"
+            "print(TOKEN)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+
+    with repo_fixture() as repo:
+        (repo / "src" / "unrelated.py").write_text(
+            "import os\n"
+            "print('booting')\n"
+            "TOKEN = os.getenv('API_KEY')\n"
+            "print('ready')\n"
+            "message = 'ok'\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "warning"
+        assert "sink=" not in findings[0]["evidence"]
+
+
+def test_sensitive_input_unchanged_and_broad_secret_names_do_not_hit() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "seed.py").write_text("import os\nTOKEN = os.environ['API_KEY']\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed sensitive read")
+        (repo / "src" / "seed.py").write_text(
+            "import os\nTOKEN = os.environ['API_KEY']\nVALUE = 1\n", encoding="utf-8"
+        )
+        (repo / "src" / "names.py").write_text(
+            "secret_payload = load_user_setting()\n"
+            "if os.environ:\n"
+            "    value = 1\n",
+            encoding="utf-8",
+        )
+        (repo / "src" / "headers.ts").write_text("const AUTH_HEADER = 'Authorization';\n", encoding="utf-8")
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "securityAssumptionFindings") == []
+
+
+def test_sensitive_input_test_fixtures_do_not_hit() -> None:
+    with repo_fixture() as repo:
+        (repo / "tests" / "test_secrets.py").write_text(
+            "import os\ndef test_fake_secret(tmp_path):\n"
+            "    token = os.environ['API_KEY']\n"
+            "    (tmp_path / 'out.txt').write_text(token)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "securityAssumptionFindings") == []
+
+def test_sensitive_input_text_output_is_advisory_only() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "secrets.py").write_text("import os\nTOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
+        result = run_gate(repo, "check", "--repo", str(repo))
+        assert result.returncode == 0
+        assert "Advisory findings" in result.stdout
+        assert "Warnings:\n- none" in result.stdout
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1208,6 +1315,12 @@ def test_gate_check_creates_no_repo_artifacts() -> None:
 
 TESTS = [
     test_p0_advisory_groups_are_empty_and_compatible,
+    test_sensitive_input_source_only_is_advisory,
+    test_sensitive_input_source_and_sink_is_stronger_advisory,
+    test_sensitive_input_high_requires_same_line_or_source_identifier_flow,
+    test_sensitive_input_unchanged_and_broad_secret_names_do_not_hit,
+    test_sensitive_input_test_fixtures_do_not_hit,
+    test_sensitive_input_text_output_is_advisory_only,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -253,6 +253,51 @@ def test_sensitive_input_test_fixtures_do_not_hit() -> None:
         assert code == 0, data
         assert _advisory_added(data, "securityAssumptionFindings") == []
 
+
+def test_sensitive_input_credential_paths_require_read_call() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "paths.py").write_text(
+            "DEFAULT_KEY = '.ssh/id_ed25519'\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "securityAssumptionFindings") == []
+        (repo / "src" / "paths.py").write_text(
+            "KEY = open('.ssh/id_ed25519').read()\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["evidence"] == "source=credential-file-read"
+
+
+def test_sensitive_input_added_source_escalates_to_existing_sink() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "existing.py").write_text(
+            "def load():\n"
+            "    print(TOKEN)\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed sink")
+        (repo / "src" / "existing.py").write_text(
+            "import os\n"
+            "def load():\n"
+            "    TOKEN = os.getenv('API_KEY')\n"
+            "    print(TOKEN)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+
+
 def test_sensitive_input_indented_python_assignment_escalates_via_identifier_flow() -> None:
     with repo_fixture() as repo:
         (repo / "src" / "indented.py").write_text(
@@ -1435,6 +1480,8 @@ TESTS = [
     test_sensitive_input_high_requires_same_line_or_source_identifier_flow,
     test_sensitive_input_unchanged_and_broad_secret_names_do_not_hit,
     test_sensitive_input_test_fixtures_do_not_hit,
+    test_sensitive_input_credential_paths_require_read_call,
+    test_sensitive_input_added_source_escalates_to_existing_sink,
     test_sensitive_input_indented_python_assignment_escalates_via_identifier_flow,
     test_sensitive_input_typed_python_assignment_escalates_via_identifier_flow,
     test_sensitive_input_comparison_does_not_escalate,

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -253,6 +253,87 @@ def test_sensitive_input_test_fixtures_do_not_hit() -> None:
         assert code == 0, data
         assert _advisory_added(data, "securityAssumptionFindings") == []
 
+def test_sensitive_input_indented_python_assignment_escalates_via_identifier_flow() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "indented.py").write_text(
+            "import os\n"
+            "def load():\n"
+            "    TOKEN = os.getenv('API_KEY')\n"
+            "    print('starting')\n"
+            "    print(TOKEN)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+
+
+def test_sensitive_input_typed_python_assignment_escalates_via_identifier_flow() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "typed.py").write_text(
+            "import os\n"
+            "from typing import Optional\n"
+            "TOKEN: Optional[str] = os.getenv('API_KEY')\n"
+            "print(TOKEN)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+
+
+def test_sensitive_input_comparison_does_not_escalate() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "compare.py").write_text(
+            "import os\n"
+            "def check(TOKEN):\n"
+            "    if TOKEN == os.getenv('API_KEY'):\n"
+            "        print(TOKEN)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "warning"
+        assert "sink=" not in findings[0]["evidence"]
+
+
+def test_sensitive_input_git_remote_subprocess_is_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "remotes.py").write_text(
+            "import subprocess\n"
+            "def origin():\n"
+            "    return subprocess.run(['git', 'remote', 'get-url', 'origin']).stdout\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["evidence"] == "source=git-remote-url-read"
+
+
+def test_sensitive_input_git_remote_node_execfile_is_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "remotes.ts").write_text(
+            "import { execFile } from 'child_process';\n"
+            "export const origin = () => execFile('git', ['remote', 'get-url', 'origin']);\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["evidence"] == "source=git-remote-url-read"
+
+
 def test_sensitive_input_text_output_is_advisory_only() -> None:
     with repo_fixture() as repo:
         (repo / "src" / "secrets.py").write_text("import os\nTOKEN = os.getenv('API_KEY')\n", encoding="utf-8")

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -334,6 +334,40 @@ def test_sensitive_input_git_remote_node_execfile_is_advisory() -> None:
         assert findings[0]["evidence"] == "source=git-remote-url-read"
 
 
+def test_sensitive_input_python_logger_method_call_escalates() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "logged.py").write_text(
+            "import logging\n"
+            "import os\n"
+            "logger = logging.getLogger(__name__)\n"
+            "def load():\n"
+            "    TOKEN = os.getenv('API_KEY')\n"
+            "    logger.error(TOKEN)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+
+
+def test_sensitive_input_console_info_method_call_escalates() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "client.ts").write_text(
+            "const TOKEN = process.env.API_KEY;\n"
+            "console.info(TOKEN);\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        findings = _advisory_added(data, "securityAssumptionFindings")
+        assert code == 0, data
+        assert len(findings) == 1
+        assert findings[0]["severity"] == "high"
+        assert "sink=log-or-console" in findings[0]["evidence"]
+
+
 def test_sensitive_input_text_output_is_advisory_only() -> None:
     with repo_fixture() as repo:
         (repo / "src" / "secrets.py").write_text("import os\nTOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
@@ -1401,6 +1435,13 @@ TESTS = [
     test_sensitive_input_high_requires_same_line_or_source_identifier_flow,
     test_sensitive_input_unchanged_and_broad_secret_names_do_not_hit,
     test_sensitive_input_test_fixtures_do_not_hit,
+    test_sensitive_input_indented_python_assignment_escalates_via_identifier_flow,
+    test_sensitive_input_typed_python_assignment_escalates_via_identifier_flow,
+    test_sensitive_input_comparison_does_not_escalate,
+    test_sensitive_input_git_remote_subprocess_is_advisory,
+    test_sensitive_input_git_remote_node_execfile_is_advisory,
+    test_sensitive_input_python_logger_method_call_escalates,
+    test_sensitive_input_console_info_method_call_escalates,
     test_sensitive_input_text_output_is_advisory_only,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,


### PR DESCRIPTION
# 01_PR1_sensitive_input

Problem:
Added production code can read credential-bearing data and leak or persist it.

Named failure mode:
sensitive input read with optional source-to-sink evidence in touched production source

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, lean-code skill docs, supplied V1.3 plan, and reward spec scope where applicable. Supplied archive did not contain calibration/HANDOVER.md or calibration/analysis/COHORT_TABLE.md, so no current-corpus rerun is claimed.

Exact scope:
Production source added lines only. Source-only warning; high only for same-line sink or identifier flow to a later sink line.

Existing surfaces touched:
P0 securityAssumptionFindings; GateContext.added_lines_with_untracked(); is_production_source_path(); risk_check docs.

Files changed:
.agent/lean/lean_code_gate.py, .agents/skills/lean-code/SKILL.md, .claude/skills/lean-code/SKILL.md, METHODOLOGY.md, tests/test_lean_code_gate.py

Prerequisites:
00_PR0_P0_advisory_surface

Net lean_code_gate.py lines added:
+103 / -1

Total patch size:
+220 / -1

Helpers reused:
is_production_source_path(), language/path filters, advisory_finding()

Helpers added:
first_rule_match(), scan_sensitive_input(), scan_sensitive_input_lines(), assigned_identifier(), sensitive_sink_for_source()

Why existing helpers were insufficient:
Existing quality escape scanners intentionally catch suppressions, not sensitive input reads or source/sink evidence.

Deletion/consolidation attempted:
Dropped broad cache/state/status/error/message/response sinks and broad auth-string matching.

Chosen path:
Small source/sink regex set with identifier-based high severity only.

Rejected simpler paths:
Credential regex catalog, taint engine, test-file coverage, symmetric proximity high severity.

Compatibility impact:
Advisory-only JSON. No legacy warnings or blockers.

Verification:
Sensitive source, same-line/identifier-flow high severity, broad non-hit, test fixture non-hit, text-output advisory-only. See VERIFY.log and verify_after_main_merge.log.

Calibration rule:
Warning-only fixtures now. Promotion requires current-corpus attribution below duplicate-block FP baseline.

Rollback path:
Remove constants, helper calls, P0 population, docs, and tests.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/future3ooo/lean-code-gate-v3/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sensitive-input advisory scan that detects secret-bearing reads (env, credential/keyring data, auth/cookie headers, private keys, git URLs) and escalates to high when those values are observed being logged, serialized, or persisted; advisory findings are now returned and summarized with sample listings.

* **Documentation**
  * Updated implementation rules and methodology to require documenting sensitive-input paths and forbid exposing or persisting secret values.

* **Tests**
  * Added comprehensive tests for detection, escalation, redaction, and human-readable reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->