### PR TITLE
P2: Add failure-contract advisory findings

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1327,12 +1327,7 @@ def assigned_identifier(text: str) -> str:
 
 
 def scan_failure_contract(ctx: GateContext) -> list[dict[str, object]]:
-    return [
-        finding
-        for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items()
-        if is_production_source_path(rel_path) and language_for_path(rel_path) == "javascript"
-        for finding in scan_failure_contract_lines(rel_path, lines)
-    ]
+    return [finding for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items() if is_production_source_path(rel_path) and language_for_path(rel_path) == "javascript" for finding in scan_failure_contract_lines(rel_path, lines)]
 
 def scan_failure_contract_lines(path: str, lines: list[tuple[int, str]]) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
@@ -1344,26 +1339,19 @@ def scan_failure_contract_lines(path: str, lines: list[tuple[int, str]]) -> list
         if not re.search(r"\bcatch\b|\.catch\b", window):
             continue
         after_catch = "\n".join(value for current, value in window_lines if current >= line_no)
+        catch_here = re.search(r"\bcatch\b|\.catch\b", text)
+        catch_line = max((current for current, value in window_lines if current < line_no and re.search(r"\bcatch\b|\.catch\b", value)), default=None)
+        inside_catch = bool(catch_here) or (catch_line is not None and (body := "".join(value for current, value in window_lines if catch_line <= current < line_no)).count("{") > body.count("}"))
         rule = message = ""
         if FAILURE_STRINGIFY_RE.search(text):
             rule, message = "failure-contract-stringify", "caught error is stringified instead of preserved or mapped"
-        elif FAILURE_DEFAULT_RE.search(text) and inside_open_catch(window_lines, line_no, text):
+        elif FAILURE_DEFAULT_RE.search(text) and inside_catch:
             rule, message = "failure-contract-cheap-default", "catch path returns a cheap default instead of preserving failure information"
-        elif re.search(r"\bcatch\b|\.catch\b", text) and FAILURE_LOG_RE.search(window) and not FAILURE_RETHROW_RE.search(window) and not re.search(r"\breturn\b", after_catch):
+        elif catch_here and FAILURE_LOG_RE.search(window) and not FAILURE_RETHROW_RE.search(window) and not re.search(r"\breturn\b", after_catch):
             rule, message = "failure-contract-log-only", "catch path only logs and then erases the failure"
         if rule:
             findings.append(advisory_finding(rule, "failure-contract", path, line_no, "warning", message, "added catch/reject path erases failure shape"))
     return findings
-
-
-def inside_open_catch(window_lines: list[tuple[int, str]], line_no: int, text: str) -> bool:
-    if re.search(r"\bcatch\b|\.catch\b", text):
-        return True
-    catch_line = max((current for current, value in window_lines if current < line_no and re.search(r"\bcatch\b|\.catch\b", value)), default=None)
-    if catch_line is None:
-        return False
-    body = "".join(value for current, value in window_lines if catch_line <= current < line_no)
-    return body.count("{") - body.count("}") > 0
 
 
 def multiline_hits(path: str, text: str) -> list[str]:

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -332,13 +332,12 @@ SENSITIVE_SINK_RULES = [
     (re.compile(r"\b(?:JSON\.stringify|json\.dumps|pickle\.dump|yaml\.dump|serialize|snapshot)\b|\b(?:telemetry|metrics)\.(?:track|emit|record|log)\s*\("), "serialization-or-telemetry"),
     (re.compile(r"""\b(?:write_text|write_bytes|writeFile|appendFile|fs\.(?:writeFile|appendFile)|open\s*\([^)]*['"]w)\b"""), "persistence"),
 ]
-SENSITIVE_IDENTIFIER_RE = re.compile(
-    r"^\s*"
-    r"(?:(?:const|let|var)\s+)?"
-    r"([A-Za-z_$][\w$]*)"
-    r"(?:\s*:\s*[^=]+?)?"
-    r"\s*(?::=|=(?!=))"
-)
+SENSITIVE_IDENTIFIER_RE = re.compile(r"^\s*(?:(?:const|let|var)\s+)?([A-Za-z_$][\w$]*)(?:\s*:\s*[^=]+?)?\s*(?::=|=(?!=))")
+FAILURE_DEFAULT_RE = re.compile(r'(?:\breturn\s+|=>\s*|Promise\.resolve\s*\(\s*)(?:null|undefined|false|\[\]|\{\}|["\']{2})(?=[\s;),}]|$)')
+FAILURE_LOG_RE = re.compile(r"\b(?:console\.(?:log|error|warn|info)|(?:logger|log)\.(?:log|error|warn|info))\s*\(")
+FAILURE_RETHROW_RE = re.compile(r"\b(?:throw|reject)\b")
+FAILURE_STRINGIFY_RE = re.compile(r"\b(?:JSON\.stringify|String)\s*\(\s*(?:e|err|error)\s*\)")
+FAILURE_TRIGGER_RE = re.compile(r"\bcatch\b|\.catch\b|\breturn\b|=>|Promise\.resolve|JSON\.stringify|\bString\s*\(|console\.|(?:logger|log)\.")
 GENERIC_SYMBOLS = {
     "app",
     "config",
@@ -1281,20 +1280,11 @@ def line_hits(path: str, lines: list[tuple[int, str]], rules: list[re.Pattern[st
 
 
 def advisory_finding(rule: str, family: str, path: str, line: int, severity: str, message: str, evidence: str) -> dict[str, object]:
-    return {
-        "rule": rule,
-        "family": family,
-        "path": path,
-        "line": line,
-        "severity": severity,
-        "message": message,
-        "evidence": evidence,
-    }
+    return {"rule": rule, "family": family, "path": path, "line": line, "severity": severity, "message": message, "evidence": evidence}
 
 
 def first_rule_match(text: str, rules: list[tuple[re.Pattern[str], str]]) -> str:
     return next((label for pattern, label in rules if pattern.search(text)), "")
-
 
 def scan_sensitive_input(ctx: GateContext) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
@@ -1336,23 +1326,40 @@ def assigned_identifier(text: str) -> str:
     return found.group(1) if found else ""
 
 
+def scan_failure_contract(ctx: GateContext) -> list[dict[str, object]]:
+    return [
+        finding
+        for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items()
+        if is_production_source_path(rel_path) and language_for_path(rel_path) == "javascript"
+        for finding in scan_failure_contract_lines(rel_path, lines)
+    ]
+
+def scan_failure_contract_lines(path: str, lines: list[tuple[int, str]]) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for line_no, text in lines:
+        if not FAILURE_TRIGGER_RE.search(text):
+            continue
+        window = "\n".join(value for current, value in lines if abs(current - line_no) <= 8)
+        if not re.search(r"\bcatch\b|\.catch\b", window):
+            continue
+        rule = message = ""
+        if FAILURE_STRINGIFY_RE.search(text):
+            rule, message = "failure-contract-stringify", "caught error is stringified instead of preserved or mapped"
+        elif FAILURE_DEFAULT_RE.search(text):
+            rule, message = "failure-contract-cheap-default", "catch path returns a cheap default instead of preserving failure information"
+        elif re.search(r"\bcatch\b|\.catch\b", text) and FAILURE_LOG_RE.search(window) and not FAILURE_RETHROW_RE.search(window) and not re.search(r"\breturn\b", window):
+            rule, message = "failure-contract-log-only", "catch path only logs and then erases the failure"
+        if rule:
+            findings.append(advisory_finding(rule, "failure-contract", path, line_no, "warning", message, "added catch/reject path erases failure shape"))
+    return findings
+
+
 def multiline_hits(path: str, text: str) -> list[str]:
     return [f"{path}:{text[: match.start()].count(chr(10)) + 1}" for rule in EMPTY_CATCH_RULES for match in rule.finditer(text)]
 
 
 def scan_quality_escapes(ctx: GateContext) -> list[str]:
-    # Path filter is is_source_path (not is_production_source_path) by design.
-    # Reuse/duplicate/bloat detectors filter to is_production_source_path
-    # because their findings are scoped to the new code's relationship to
-    # the production codebase. Quality-escape's path filter is broader so
-    # GENERAL_ESCAPE_RULES (TODO/FIXME, # type: ignore, @ts-ignore,
-    # eslint-disable, # noqa, || true) catches escapes in test/fixture
-    # paths too — those locations are particularly prone to vestigial
-    # suppressions (Wen et al. FSE 2025: 50.8% of suppressions are useless).
-    # Language-typed rules (PYTHON_ESCAPE_RULES, TS_ESCAPE_RULES — `: Any`,
-    # `as any`, bare `except:`) DO restrict to production via
-    # is_production_source_path inside rules_for_path; mocks in tests
-    # legitimately use `as any` and shouldn't trip this layer.
+    # General escape rules cover all changed source; language-typed rules stay production-only via rules_for_path().
     hits: list[str] = []
     for rel_path, lines in ctx.added_lines.items():
         if is_source_path(rel_path):
@@ -1497,16 +1504,7 @@ def bloat_file_details(ctx: GateContext) -> tuple[list[dict[str, object]], int, 
         parent = str(Path(rel_path).parent).replace(os.sep, "/")
         if deleted > added:
             shrink_by_dir[parent] = shrink_by_dir.get(parent, 0) + deleted - added
-        details.append(
-            {
-                "file": rel_path,
-                "added": added,
-                "deleted": deleted,
-                "currentLines": current_lines,
-                "baselineLines": baseline_lines,
-                "netGrowth": max(0, added - deleted),
-            }
-        )
+        details.append({"file": rel_path, "added": added, "deleted": deleted, "currentLines": current_lines, "baselineLines": baseline_lines, "netGrowth": max(0, added - deleted)})
     return details, total_added, total_deleted, shrink_by_dir
 
 
@@ -1843,6 +1841,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     reuse_warnings = [finding for finding in reuse_findings if finding.severity == "warning"]
     advisory_groups = empty_advisory_groups()
     advisory_groups["securityAssumptionFindings"]["added"].extend(scan_sensitive_input(ctx))
+    advisory_groups["slopShapeFindings"]["added"].extend(scan_failure_contract(ctx))
 
     if conflict_files:
         errors.append(f"merge conflict markers found in {len(conflict_files)} file(s)")

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1339,19 +1339,31 @@ def scan_failure_contract_lines(path: str, lines: list[tuple[int, str]]) -> list
     for line_no, text in lines:
         if not FAILURE_TRIGGER_RE.search(text):
             continue
-        window = "\n".join(value for current, value in lines if abs(current - line_no) <= 8)
+        window_lines = [(current, value) for current, value in lines if abs(current - line_no) <= 8]
+        window = "\n".join(value for _, value in window_lines)
         if not re.search(r"\bcatch\b|\.catch\b", window):
             continue
+        after_catch = "\n".join(value for current, value in window_lines if current >= line_no)
         rule = message = ""
         if FAILURE_STRINGIFY_RE.search(text):
             rule, message = "failure-contract-stringify", "caught error is stringified instead of preserved or mapped"
-        elif FAILURE_DEFAULT_RE.search(text):
+        elif FAILURE_DEFAULT_RE.search(text) and inside_open_catch(window_lines, line_no, text):
             rule, message = "failure-contract-cheap-default", "catch path returns a cheap default instead of preserving failure information"
-        elif re.search(r"\bcatch\b|\.catch\b", text) and FAILURE_LOG_RE.search(window) and not FAILURE_RETHROW_RE.search(window) and not re.search(r"\breturn\b", window):
+        elif re.search(r"\bcatch\b|\.catch\b", text) and FAILURE_LOG_RE.search(window) and not FAILURE_RETHROW_RE.search(window) and not re.search(r"\breturn\b", after_catch):
             rule, message = "failure-contract-log-only", "catch path only logs and then erases the failure"
         if rule:
             findings.append(advisory_finding(rule, "failure-contract", path, line_no, "warning", message, "added catch/reject path erases failure shape"))
     return findings
+
+
+def inside_open_catch(window_lines: list[tuple[int, str]], line_no: int, text: str) -> bool:
+    if re.search(r"\bcatch\b|\.catch\b", text):
+        return True
+    catch_line = max((current for current, value in window_lines if current < line_no and re.search(r"\bcatch\b|\.catch\b", value)), default=None)
+    if catch_line is None:
+        return False
+    body = "".join(value for current, value in window_lines if catch_line <= current < line_no)
+    return body.count("{") - body.count("}") > 0
 
 
 def multiline_hits(path: str, text: str) -> list[str]:

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -490,6 +490,35 @@ def test_failure_contract_preserved_errors_tests_and_unchanged_catches_do_not_hi
         assert _advisory_added(data, "slopShapeFindings") == []
 
 
+def test_failure_contract_log_only_fires_when_try_block_returns() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "client.ts").write_text(
+            "export async function load() {\n"
+            "  try { return await api.get(); }\n"
+            "  catch (error) { logger.error(error); }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert [item["rule"] for item in _advisory_added(data, "slopShapeFindings")] == ["failure-contract-log-only"]
+
+
+def test_failure_contract_cheap_default_skips_returns_outside_catch_body() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "validate.ts").write_text(
+            "export function validate(x: unknown) {\n"
+            "  try { parse(x); }\n"
+            "  catch (error) { throw mapError(error); }\n"
+            "  return false;\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "slopShapeFindings") == []
+
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1563,6 +1592,8 @@ TESTS = [
     test_failure_contract_multiline_default_is_advisory,
     test_failure_contract_stringified_unknown_is_advisory,
     test_failure_contract_preserved_errors_tests_and_unchanged_catches_do_not_hit,
+    test_failure_contract_log_only_fires_when_try_block_returns,
+    test_failure_contract_cheap_default_skips_returns_outside_catch_body,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -427,6 +427,69 @@ def test_sensitive_input_text_output_is_advisory_only() -> None:
         assert "Advisory findings" in result.stdout
         assert "Warnings:\n- none" in result.stdout
 
+
+def test_failure_contract_defaults_and_log_only_are_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "client.ts").write_text(
+            "export const load = () => fetch('/x').catch(() => null);\n"
+            "export const save = () => fetch('/y').catch(err => { console.error(err); });\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        rules = {item["rule"] for item in _advisory_added(data, "slopShapeFindings")}
+        assert code == 0, data
+        assert rules == {"failure-contract-cheap-default", "failure-contract-log-only"}
+        assert data["warnings"] == []
+
+
+def test_failure_contract_multiline_default_is_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "client.ts").write_text(
+            "export async function load() {\n"
+            "  try { return await fetch('/x'); }\n"
+            "  catch (error) {\n"
+            "    console.error(error);\n"
+            "    return undefined;\n"
+            "  }\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert [item["rule"] for item in _advisory_added(data, "slopShapeFindings")] == ["failure-contract-cheap-default"]
+
+
+def test_failure_contract_stringified_unknown_is_advisory() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "client.ts").write_text(
+            "export function load() { try { return read(); } catch (error) { return JSON.stringify(error); } }\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert [item["rule"] for item in _advisory_added(data, "slopShapeFindings")] == ["failure-contract-stringify"]
+
+
+def test_failure_contract_preserved_errors_tests_and_unchanged_catches_do_not_hit() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "seed.ts").write_text("export function load() { try { return read(); } catch (error) { return null; } }\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed catch")
+        (repo / "src" / "seed.ts").write_text("export function load() { try { return read(); } catch (error) { return null; } }\nexport const ok = 1;\n", encoding="utf-8")
+        (repo / "src" / "safe.ts").write_text(
+            "export function safe() { try { return read(); } catch (error) { throw mapDomainError(error); } }\n"
+            "export const boundary = () => read().catch(error => ({ ok: false, error }));\n",
+            encoding="utf-8",
+        )
+        (repo / "tests" / "test_client.ts").write_text(
+            "test('error shape', () => { try { read(); } catch (error) { return JSON.stringify(error); } });\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert _advisory_added(data, "slopShapeFindings") == []
+
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1496,6 +1559,10 @@ TESTS = [
     test_sensitive_input_python_logger_method_call_escalates,
     test_sensitive_input_console_info_method_call_escalates,
     test_sensitive_input_text_output_is_advisory_only,
+    test_failure_contract_defaults_and_log_only_are_advisory,
+    test_failure_contract_multiline_default_is_advisory,
+    test_failure_contract_stringified_unknown_is_advisory,
+    test_failure_contract_preserved_errors_tests_and_unchanged_catches_do_not_hit,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,


### PR DESCRIPTION
## Summary
- Adds P2 TS/JS failure-contract advisory findings under `slopShapeFindings`.
- Flags touched catch / `.catch` paths that stringify unknown errors, return cheap defaults, or only log and erase failure shape.
- Keeps findings advisory-only: no legacy warnings, hard rules, or `--fail-on-warnings` behavior changes.

## Lean constraints
- Targets `main`; not stacked on P1.
- Runtime core is net smaller after the slice (`lean_code_gate.py` 2464 -> 2463 lines).
- No AST dependency, no whole-file/repo scan, no docs churn.

## Verification
- `cd lean-code-gate-v3 && PYTHONDONTWRITEBYTECODE=1 python3 -B -S tests/test_lean_code_gate.py` -> 73 tests passed.
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S /home/prop_/.codex/lean-code-gate-v3/lean_code_gate.py check --repo "$PWD" --json` -> ok.
- `PYTHONDONTWRITEBYTECODE=1 python3 "$HOME/.codex/skills/production-code/scripts/code_quality_gate.py" check --repo "$PWD"` -> pass.
- `git diff --check` -> pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a JavaScript error-handling advisory that flags catch/reject paths that may erase or weaken failure information, classifying issues as stringified errors, cheap-default returns, or log-only handling.

* **Tests**
  * Added targeted tests covering the new advisory’s detection and non-detection scenarios.

* **Refactor**
  * Minor internal formatting/simplifications with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->