### PR TITLE
P3: Add wrapper-value advisory findings

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -338,6 +338,10 @@ FAILURE_LOG_RE = re.compile(r"\b(?:console\.(?:log|error|warn|info)|(?:logger|lo
 FAILURE_RETHROW_RE = re.compile(r"\b(?:throw|reject)\b")
 FAILURE_STRINGIFY_RE = re.compile(r"\b(?:JSON\.stringify|String)\s*\(\s*(?:e|err|error)\s*\)")
 FAILURE_TRIGGER_RE = re.compile(r"\bcatch\b|\.catch\b|\breturn\b|=>|Promise\.resolve|JSON\.stringify|\bString\s*\(|console\.|(?:logger|log)\.")
+WRAPPER_VALUE_MARKER_RE = re.compile(
+    r"\b(?:compat|deprecated|deprecation|alias|public\s+api|validate|validation|normalize|normalise|sanitize|instrument(?:ation)?|metric|trace|retry|timeout|boundary|external|adapter)\b",
+    re.I,
+)
 GENERIC_SYMBOLS = {
     "app",
     "config",
@@ -1286,6 +1290,18 @@ def advisory_finding(rule: str, family: str, path: str, line: int, severity: str
 def first_rule_match(text: str, rules: list[tuple[re.Pattern[str], str]]) -> str:
     return next((label for pattern, label in rules if pattern.search(text)), "")
 
+
+def unique_advisory_findings(findings: list[dict[str, object]]) -> list[dict[str, object]]:
+    seen: set[tuple[object, object, object, object]] = set()
+    out: list[dict[str, object]] = []
+    for finding in findings:
+        key = (finding.get("rule"), finding.get("path"), finding.get("line"), finding.get("evidence"))
+        if key not in seen:
+            seen.add(key)
+            out.append(finding)
+    return out
+
+
 def scan_sensitive_input(ctx: GateContext) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
     for rel_path, added_lines in ctx.added_lines_with_untracked(production_only=True).items():
@@ -1352,6 +1368,100 @@ def scan_failure_contract_lines(path: str, lines: list[tuple[int, str]]) -> list
         if rule:
             findings.append(advisory_finding(rule, "failure-contract", path, line_no, "warning", message, "added catch/reject path erases failure shape"))
     return findings
+
+
+def scan_wrapper_value(ctx: GateContext) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items():
+        if is_production_source_path(rel_path):
+            findings.extend(scan_wrapper_value_lines(rel_path, lines))
+    return unique_advisory_findings(findings)
+
+
+def scan_wrapper_value_lines(path: str, lines: list[tuple[int, str]]) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    language = language_for_path(path)
+    for index, (line_no, text) in enumerate(lines):
+        match_info = wrapper_forwarder(language, text)
+        if not match_info and language in {"python", "go"}:
+            match_info = wrapper_forwarder(language, "\n".join(part.strip() for _, part in lines[index:index + 3]))
+        if not match_info:
+            continue
+        name, target, args, call_args = match_info
+        if name in _active_framework_override_names or target.rsplit(".", 1)[-1] == name:
+            continue
+        if not same_pass_through_args(args, call_args) or wrapper_has_value_marker(lines, line_no):
+            continue
+        findings.append(
+            advisory_finding(
+                "wrapper-value",
+                "wrapper",
+                path,
+                line_no,
+                "warning",
+                "one-body forwarding function adds indirection without visible boundary value",
+                f"{name} forwards to {target} with pass-through arguments",
+            )
+        )
+    return findings
+
+
+def wrapper_forwarder(language: str, text: str) -> tuple[str, str, str, str] | None:
+    stripped = text.strip()
+    if language == "python":
+        found = re.search(r"^(?:async\s+)?def\s+(\w+)\s*\(([^)]*)\)\s*:\s*(?:\n\s*)?return\s+(?:await\s+)?([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*\(([^)]*)\)\s*$", stripped)
+        if found:
+            return found.group(1), found.group(3), found.group(2), found.group(4)
+    elif language == "javascript":
+        found = re.search(r"^(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)\s*\{\s*return\s+(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)\s*;?\s*\}\s*$", stripped)
+        if found:
+            return found.group(1), found.group(3), found.group(2), found.group(4)
+        found = re.search(r"^(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?(.*?)\s*=>\s*(.*?)\s*;?\s*$", stripped)
+        if found:
+            name, raw_args, body = found.group(1), found.group(2).strip(), found.group(3).strip()
+            if raw_args.startswith("(") and raw_args.endswith(")"):
+                raw_args = raw_args[1:-1]
+            body_match = re.search(r"^(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)$", body)
+            if not body_match and body.startswith("{") and body.endswith("}"):
+                body_match = re.search(r"^\{\s*return\s+(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)\s*;?\s*\}$", body)
+            if body_match:
+                return name, body_match.group(1), raw_args, body_match.group(2)
+    elif language == "go":
+        found = re.search(r"^func\s+(?:\([^)]*\)\s*)?(\w+)\s*\(([^)]*)\)[^{]*\{\s*(?:\n\s*)?return\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*\(([^)]*)\)\s*(?:\n\s*)?\}\s*$", stripped)
+        if found:
+            return found.group(1), found.group(3), found.group(2), found.group(4)
+    return None
+
+
+def wrapper_has_value_marker(lines: list[tuple[int, str]], line_no: int) -> bool:
+    for current, text in lines:
+        if abs(current - line_no) > 2:
+            continue
+        stripped = text.strip()
+        if current == line_no or stripped.startswith(("#", "//", "/*", "*")):
+            if WRAPPER_VALUE_MARKER_RE.search(stripped):
+                return True
+    return False
+
+
+def argument_names(raw: str, declaration: bool) -> list[str]:
+    names: list[str] = []
+    for part in raw.split(","):
+        item = part.strip().lstrip("*").lstrip("&")
+        if not item or item.startswith(("...", "{", "[")):
+            continue
+        if declaration:
+            item = item.split("=", 1)[0].split(":", 1)[0].strip()
+            tokens = re.findall(r"[A-Za-z_$][\w$]*", item)
+            if tokens:
+                names.append(tokens[0])
+        elif re.match(r"^[A-Za-z_$][\w$]*$", item):
+            names.append(item)
+    return [name for name in names if name not in {"self", "this", "cls"}]
+
+
+def same_pass_through_args(args: str, call_args: str) -> bool:
+    return argument_names(args, declaration=True) == argument_names(call_args, declaration=False)
 
 
 def multiline_hits(path: str, text: str) -> list[str]:
@@ -1842,6 +1952,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     advisory_groups = empty_advisory_groups()
     advisory_groups["securityAssumptionFindings"]["added"].extend(scan_sensitive_input(ctx))
     advisory_groups["slopShapeFindings"]["added"].extend(scan_failure_contract(ctx))
+    advisory_groups["slopShapeFindings"]["added"].extend(scan_wrapper_value(ctx))
 
     if conflict_files:
         errors.append(f"merge conflict markers found in {len(conflict_files)} file(s)")

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1291,17 +1291,6 @@ def first_rule_match(text: str, rules: list[tuple[re.Pattern[str], str]]) -> str
     return next((label for pattern, label in rules if pattern.search(text)), "")
 
 
-def unique_advisory_findings(findings: list[dict[str, object]]) -> list[dict[str, object]]:
-    seen: set[tuple[object, object, object, object]] = set()
-    out: list[dict[str, object]] = []
-    for finding in findings:
-        key = (finding.get("rule"), finding.get("path"), finding.get("line"), finding.get("evidence"))
-        if key not in seen:
-            seen.add(key)
-            out.append(finding)
-    return out
-
-
 def scan_sensitive_input(ctx: GateContext) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
     for rel_path, added_lines in ctx.added_lines_with_untracked(production_only=True).items():
@@ -1374,23 +1363,26 @@ def scan_wrapper_value(ctx: GateContext) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
     for rel_path, lines in ctx.added_lines_with_untracked(production_only=True).items():
         if is_production_source_path(rel_path):
-            findings.extend(scan_wrapper_value_lines(rel_path, lines))
-    return unique_advisory_findings(findings)
+            text = read_file(ctx.repo / rel_path)
+            marker_lines = list(enumerate(text.splitlines(), 1)) if text is not None else lines
+            findings.extend(scan_wrapper_value_lines(rel_path, lines, marker_lines))
+    return findings
 
 
-def scan_wrapper_value_lines(path: str, lines: list[tuple[int, str]]) -> list[dict[str, object]]:
+def scan_wrapper_value_lines(path: str, lines: list[tuple[int, str]], marker_lines: list[tuple[int, str]]) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
     language = language_for_path(path)
     for index, (line_no, text) in enumerate(lines):
         match_info = wrapper_forwarder(language, text)
-        if not match_info and language in {"python", "go"}:
-            match_info = wrapper_forwarder(language, "\n".join(part.strip() for _, part in lines[index:index + 3]))
+        multiline = lines[index:index + 3]
+        if not match_info and language in {"python", "go"} and len(multiline) > 1 and all(multiline[i + 1][0] == multiline[i][0] + 1 for i in range(len(multiline) - 1)):
+            match_info = wrapper_forwarder(language, "\n".join(part.strip() for _, part in multiline))
         if not match_info:
             continue
         name, target, args, call_args = match_info
         if name in _active_framework_override_names or target.rsplit(".", 1)[-1] == name:
             continue
-        if not same_pass_through_args(args, call_args) or wrapper_has_value_marker(lines, line_no):
+        if not same_pass_through_args(args, call_args) or wrapper_has_value_marker(marker_lines, line_no):
             continue
         findings.append(
             advisory_finding(
@@ -1413,14 +1405,14 @@ def wrapper_forwarder(language: str, text: str) -> tuple[str, str, str, str] | N
         if found:
             return found.group(1), found.group(3), found.group(2), found.group(4)
     elif language == "javascript":
-        found = re.search(r"^(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)\s*\{\s*return\s+(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)\s*;?\s*\}\s*$", stripped)
+        found = re.search(r"^(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)\s*(?::\s*[^{]+)?\{\s*return\s+(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)\s*;?\s*\}\s*$", stripped)
         if found:
             return found.group(1), found.group(3), found.group(2), found.group(4)
         found = re.search(r"^(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?(.*?)\s*=>\s*(.*?)\s*;?\s*$", stripped)
         if found:
             name, raw_args, body = found.group(1), found.group(2).strip(), found.group(3).strip()
-            if raw_args.startswith("(") and raw_args.endswith(")"):
-                raw_args = raw_args[1:-1]
+            if raw_args.startswith("(") and (close := raw_args.rfind(")")) >= 0:
+                raw_args = raw_args[1:close]
             body_match = re.search(r"^(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)$", body)
             if not body_match and body.startswith("{") and body.endswith("}"):
                 body_match = re.search(r"^\{\s*return\s+(?:await\s+)?([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(([^)]*)\)\s*;?\s*\}$", body)
@@ -1447,8 +1439,8 @@ def wrapper_has_value_marker(lines: list[tuple[int, str]], line_no: int) -> bool
 def argument_names(raw: str, declaration: bool) -> list[str]:
     names: list[str] = []
     for part in raw.split(","):
-        item = part.strip().lstrip("*").lstrip("&")
-        if not item or item.startswith(("...", "{", "[")):
+        item = part.strip().removeprefix("...").lstrip("*").lstrip("&")
+        if not item or item.startswith(("{", "[")):
             continue
         if declaration:
             item = item.split("=", 1)[0].split(":", 1)[0].strip()

--- a/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.agents/skills/lean-code/SKILL.md
@@ -107,7 +107,7 @@ Escape hatches need evidence:
 
 - Minimum code that solves the requested behavior.
 - Extend existing implementation before adding a parallel one.
-- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, or configuration knobs.
+- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, configuration knobs, or forwarding wrappers without validation, normalization, instrumentation, retry, compatibility, deprecation, or boundary value.
 - No new package if standard library or an existing package solves the problem cleanly.
 - No second package manager or second lockfile.
 - No broad error handling for impossible scenarios.

--- a/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
+++ b/lean-code-gate-v3/.claude/skills/lean-code/SKILL.md
@@ -107,7 +107,7 @@ Escape hatches need evidence:
 
 - Minimum code that solves the requested behavior.
 - Extend existing implementation before adding a parallel one.
-- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, or configuration knobs.
+- No single-use factories, managers, registries, adapters, strategies, plugins, feature flags, configuration knobs, or forwarding wrappers without validation, normalization, instrumentation, retry, compatibility, deprecation, or boundary value.
 - No new package if standard library or an existing package solves the problem cleanly.
 - No second package manager or second lockfile.
 - No broad error handling for impossible scenarios.

--- a/lean-code-gate-v3/METHODOLOGY.md
+++ b/lean-code-gate-v3/METHODOLOGY.md
@@ -84,7 +84,7 @@ The final quality gate inspects the changed source scope and fails on:
 - high-confidence helper or loop reimplementation
 - risk-calibrated bloat
 
-The advisory surface also reports sensitive-input reads when changed code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value.
+The advisory surface also reports sensitive-input reads when changed code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value. TypeScript and JavaScript catch/reject paths are advisory findings when they only log, stringify unknown errors, or return cheap defaults such as `null`, `undefined`, `false`, empty arrays, empty objects, or empty strings. One-body forwarding wrappers are advisory findings when no validation, normalization, instrumentation, retry, compatibility, deprecation, or boundary value is visible nearby.
 
 Warnings are emitted for moderate bloat and weaker reuse signals. Projects can promote warnings to failures in `.agent/lean/policy.json`.
 

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -519,6 +519,35 @@ def test_failure_contract_cheap_default_skips_returns_outside_catch_body() -> No
         assert _advisory_added(data, "slopShapeFindings") == []
 
 
+def test_wrapper_value_detects_python_ts_and_go_forwarders() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "wrap.py").write_text("def get_user(user_id):\n    return load_user(user_id)\n", encoding="utf-8")
+        (repo / "src" / "wrap.ts").write_text("export const getAccount = (id: string) => loadAccount(id);\n", encoding="utf-8")
+        (repo / "src" / "wrap.go").write_text("package main\nfunc ReadUser(id string) User {\n    return GetUser(id)\n}\n", encoding="utf-8")
+        code, data = check_json(repo)
+        findings = [item for item in _advisory_added(data, "slopShapeFindings") if item["rule"] == "wrapper-value"]
+        assert code == 0, data
+        assert len(findings) == 3
+        assert {item["path"] for item in findings} == {"src/wrap.py", "src/wrap.ts", "src/wrap.go"}
+
+
+def test_wrapper_value_markers_and_framework_overrides_do_not_hit() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "compat.py").write_text(
+            "# deprecated compatibility shim for old public API\n"
+            "def old_user(user_id): return load_user(user_id)\n"
+            "# instrumentation boundary keeps metrics stable\n"
+            "def traced_user(user_id): return load_user(user_id)\n"
+            "# retry adapter for external boundary\n"
+            "def fetch_user(user_id): return load_user(user_id)\n"
+            "def render(self): return base_render(self)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert [item for item in _advisory_added(data, "slopShapeFindings") if item["rule"] == "wrapper-value"] == []
+
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1594,6 +1623,8 @@ TESTS = [
     test_failure_contract_preserved_errors_tests_and_unchanged_catches_do_not_hit,
     test_failure_contract_log_only_fires_when_try_block_returns,
     test_failure_contract_cheap_default_skips_returns_outside_catch_body,
+    test_wrapper_value_detects_python_ts_and_go_forwarders,
+    test_wrapper_value_markers_and_framework_overrides_do_not_hit,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -522,12 +522,17 @@ def test_failure_contract_cheap_default_skips_returns_outside_catch_body() -> No
 def test_wrapper_value_detects_python_ts_and_go_forwarders() -> None:
     with repo_fixture() as repo:
         (repo / "src" / "wrap.py").write_text("def get_user(user_id):\n    return load_user(user_id)\n", encoding="utf-8")
-        (repo / "src" / "wrap.ts").write_text("export const getAccount = (id: string) => loadAccount(id);\n", encoding="utf-8")
+        (repo / "src" / "wrap.ts").write_text(
+            "export const getAccount = (id: string): Promise<Account> => loadAccount(id);\n"
+            "export const getMany = (...args: Request[]) => loadMany(...args);\n"
+            "export function saveUser(user: User): Promise<void> { return persistUser(user); }\n",
+            encoding="utf-8",
+        )
         (repo / "src" / "wrap.go").write_text("package main\nfunc ReadUser(id string) User {\n    return GetUser(id)\n}\n", encoding="utf-8")
         code, data = check_json(repo)
         findings = [item for item in _advisory_added(data, "slopShapeFindings") if item["rule"] == "wrapper-value"]
         assert code == 0, data
-        assert len(findings) == 3
+        assert len(findings) == 5
         assert {item["path"] for item in findings} == {"src/wrap.py", "src/wrap.ts", "src/wrap.go"}
 
 
@@ -541,6 +546,43 @@ def test_wrapper_value_markers_and_framework_overrides_do_not_hit() -> None:
             "# retry adapter for external boundary\n"
             "def fetch_user(user_id): return load_user(user_id)\n"
             "def render(self): return base_render(self)\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert [item for item in _advisory_added(data, "slopShapeFindings") if item["rule"] == "wrapper-value"] == []
+
+
+def test_wrapper_value_uses_existing_marker_comments_on_tracked_files() -> None:
+    with repo_fixture() as repo:
+        (repo / "src" / "compat.ts").write_text(
+            "// compatibility boundary for public API\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed marker")
+        (repo / "src" / "compat.ts").write_text(
+            "// compatibility boundary for public API\n"
+            "export const getAccount = (id: string) => loadAccount(id);\n",
+            encoding="utf-8",
+        )
+        code, data = check_json(repo)
+        assert code == 0, data
+        assert [item for item in _advisory_added(data, "slopShapeFindings") if item["rule"] == "wrapper-value"] == []
+
+    with repo_fixture() as repo:
+        (repo / "src" / "users.py").write_text(
+            "def get_user(user_id):\n"
+            "    result = validate(user_id)\n"
+            "    return load_user(result)\n",
+            encoding="utf-8",
+        )
+        git(repo, "add", ".")
+        git(repo, "commit", "--no-gpg-sign", "-m", "seed non-forwarder")
+        (repo / "src" / "users.py").write_text(
+            "def get_user(account_id):\n"
+            "    result = validate(user_id)\n"
+            "    return load_user(account_id)\n",
             encoding="utf-8",
         )
         code, data = check_json(repo)
@@ -1625,6 +1667,7 @@ TESTS = [
     test_failure_contract_cheap_default_skips_returns_outside_catch_body,
     test_wrapper_value_detects_python_ts_and_go_forwarders,
     test_wrapper_value_markers_and_framework_overrides_do_not_hit,
+    test_wrapper_value_uses_existing_marker_comments_on_tracked_files,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,


### PR DESCRIPTION
## Summary
- Rebuilt PR44 from the creator production zip P3 wrapper-value slice.
- Adds wrapper-value advisories for Python, TypeScript/JavaScript, and Go one-body forwarding wrappers.
- Updates both Lean Code skills and METHODOLOGY.md with the wrapper-value guidance.
- Removes the previous unrelated DEFAULT_POLICY formatting compaction and the hand-rolled JS/TS-only replacement.
- Follow-up fixes: full-file marker context for tracked files, removed unused dedupe helper, guarded multiline fallback against non-adjacent diff lines, and supports TS return annotations/rest args.

## Verification
- cd lean-code-gate-v3 && PYTHONDONTWRITEBYTECODE=1 python3 -B -S tests/test_lean_code_gate.py
- PYTHONDONTWRITEBYTECODE=1 python3 -B -S /home/prop_/.codex/lean-code-gate-v3/lean_code_gate.py check --repo "$PWD" --json
- git diff --check

## Known Check Result
- production-code gate reports runtime growth because this creator P3 slice adds runtime code to lean_code_gate.py. I did not offset that with unrelated formatting compression.