### PR TITLE
P6: add advisory delta reporting

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1601,11 +1601,11 @@ def advisory_snapshot_findings(path: str, text: str | None, group_name: str) -> 
 
 
 def add_advisory_delta(bucketed: dict[str, list[dict[str, object]]], base: list[dict[str, object]], current: list[dict[str, object]]) -> None:
-    base_keys = {advisory_delta_key(item) for item in base}
-    current_keys = {advisory_delta_key(item) for item in current}
+    base_keys = {advisory_resolved_key(item) for item in base}
+    current_keys = {advisory_resolved_key(item) for item in current}
     resolved_keys = base_keys - current_keys
-    existing_resolved = {advisory_delta_key(item) for item in bucketed["resolved"]}
-    bucketed["resolved"].extend(item for item in base if advisory_delta_key(item) in resolved_keys and advisory_delta_key(item) not in existing_resolved)
+    existing_resolved = {advisory_resolved_key(item) for item in bucketed["resolved"]}
+    bucketed["resolved"].extend(item for item in base if advisory_resolved_key(item) in resolved_keys and advisory_resolved_key(item) not in existing_resolved)
     for key, base_count in base_count_keys(base).items():
         current_count = base_count_keys(current).get(key, 0)
         if current_count > base_count:
@@ -1616,6 +1616,12 @@ def add_advisory_delta(bucketed: dict[str, list[dict[str, object]]], base: list[
 
 def advisory_delta_key(item: dict[str, object]) -> tuple[object, ...]:
     return (item.get("rule"), item.get("family"), item.get("path"), item.get("line"), item.get("severity"), item.get("message"), item.get("evidence"))
+
+
+def advisory_resolved_key(item: dict[str, object]) -> tuple[object, ...]:
+    if item.get("rule") == "production-shaped-proof":
+        return (item.get("rule"), item.get("family"), item.get("path"), item.get("severity"), item.get("message"))
+    return advisory_delta_key(item)
 
 
 def advisory_count_key(item: dict[str, object]) -> tuple[str, str, str, str]:

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1562,6 +1562,79 @@ def production_entrypoint_line(text: str) -> bool:
     return bool(PROOF_ENTRY_RE.search(text))
 
 
+def apply_advisory_delta(ctx: GateContext, groups: dict[str, dict[str, list[dict[str, object]]]]) -> None:
+    for rel_path in sorted(ctx.changed_files):
+        if internal_gate_path(rel_path) or is_binary_path(rel_path):
+            continue
+        base_text = read_git_file(ctx.repo, ctx.base_for_file, rel_path)
+        current_text = read_file(ctx.repo / rel_path)
+        for group_name in ADVISORY_GROUP_NAMES:
+            base = advisory_snapshot_findings(rel_path, base_text, group_name)
+            current = advisory_snapshot_findings(rel_path, current_text, group_name)
+            add_advisory_delta(groups[group_name], base, current)
+
+
+def advisory_snapshot_findings(path: str, text: str | None, group_name: str) -> list[dict[str, object]]:
+    if text is None:
+        return []
+    lines = list(enumerate(text.splitlines(), 1))
+    findings: list[dict[str, object]] = []
+    if group_name == "securityAssumptionFindings" and is_production_source_path(path):
+        findings.extend(scan_sensitive_input_lines(path, lines, lines))
+    elif group_name == "slopShapeFindings":
+        if is_production_source_path(path) and language_for_path(path) == "javascript":
+            findings.extend(scan_failure_contract_lines(path, lines))
+        if is_production_source_path(path):
+            findings.extend(scan_wrapper_value_lines(path, lines, lines))
+    elif group_name == "verificationShapeFindings" and (path_type(path) == "test" or is_test_like_path(path)):
+        finding = production_shaped_proof_finding(path, lines)
+        if finding:
+            findings.append(finding)
+    unique: list[dict[str, object]] = []
+    seen: set[tuple[object, ...]] = set()
+    for item in findings:
+        key = advisory_delta_key(item)
+        if key not in seen:
+            unique.append(item)
+            seen.add(key)
+    return unique
+
+
+def add_advisory_delta(bucketed: dict[str, list[dict[str, object]]], base: list[dict[str, object]], current: list[dict[str, object]]) -> None:
+    base_keys = {advisory_delta_key(item) for item in base}
+    current_keys = {advisory_delta_key(item) for item in current}
+    resolved_keys = base_keys - current_keys
+    existing_resolved = {advisory_delta_key(item) for item in bucketed["resolved"]}
+    bucketed["resolved"].extend(item for item in base if advisory_delta_key(item) in resolved_keys and advisory_delta_key(item) not in existing_resolved)
+    for key, base_count in base_count_keys(base).items():
+        current_count = base_count_keys(current).get(key, 0)
+        if current_count > base_count:
+            bucketed["worsened"].append(advisory_delta_summary(key, base_count, current_count))
+        elif 0 < current_count < base_count:
+            bucketed["improved"].append(advisory_delta_summary(key, base_count, current_count))
+
+
+def advisory_delta_key(item: dict[str, object]) -> tuple[object, ...]:
+    return (item.get("rule"), item.get("family"), item.get("path"), item.get("line"), item.get("severity"), item.get("message"), item.get("evidence"))
+
+
+def advisory_count_key(item: dict[str, object]) -> tuple[str, str, str, str]:
+    return (str(item.get("rule") or "advisory"), str(item.get("family") or "advisory"), str(item.get("path") or ""), str(item.get("severity") or "warning"))
+
+
+def base_count_keys(findings: list[dict[str, object]]) -> dict[tuple[str, str, str, str], int]:
+    counts: dict[tuple[str, str, str, str], int] = {}
+    for item in findings:
+        key = advisory_count_key(item)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def advisory_delta_summary(key: tuple[str, str, str, str], before: int, after: int) -> dict[str, object]:
+    rule, family, path, severity = key
+    return advisory_finding(rule, family, path, 0, severity, "advisory finding count changed in touched file", f"{before} -> {after}")
+
+
 def multiline_hits(path: str, text: str) -> list[str]:
     return [f"{path}:{text[: match.start()].count(chr(10)) + 1}" for rule in EMPTY_CATCH_RULES for match in rule.finditer(text)]
 
@@ -2053,6 +2126,7 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     advisory_groups["slopShapeFindings"]["added"].extend(scan_wrapper_value(ctx))
     advisory_groups["verificationShapeFindings"]["added"].extend(scan_verification_mode(ctx, contract_snapshot(repo), active_policy))
     advisory_groups["verificationShapeFindings"]["added"].extend(scan_production_shaped_proof(ctx))
+    apply_advisory_delta(ctx, advisory_groups)
 
     if conflict_files:
         errors.append(f"merge conflict markers found in {len(conflict_files)} file(s)")

--- a/lean-code-gate-v3/METHODOLOGY.md
+++ b/lean-code-gate-v3/METHODOLOGY.md
@@ -85,6 +85,7 @@ The final quality gate inspects the changed source scope and fails on:
 - risk-calibrated bloat
 
 The advisory surface also reports sensitive-input reads when changed code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value. TypeScript and JavaScript catch/reject paths are advisory findings when they only log, stringify unknown errors, or return cheap defaults such as `null`, `undefined`, `false`, empty arrays, empty objects, or empty strings. One-body forwarding wrappers are advisory findings when no validation, normalization, instrumentation, retry, compatibility, deprecation, or boundary value is visible nearby. Full non-minimal code work also reports an advisory when `proof_plan` omits a named verification loop such as `red-green-refactor`, `green-refactor-green`, or `smoke-check`. Large mock-heavy tests with weak assertions and no visible production entrypoint are advisory proof-shape findings.
+Advisory findings are bucketed as added, resolved, improved, or worsened for touched files only. Delta buckets are reviewer ergonomics and calibration inputs; they are not blocker attribution and do not change legacy warnings, hard rules, or exit behavior.
 
 Warnings are emitted for moderate bloat and weaker reuse signals. Projects can promote warnings to failures in `.agent/lean/policy.json`.
 

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -746,6 +746,51 @@ def test_production_shaped_proof_allows_entrypoint_fixture_and_assertion_rich_te
         assert [item for item in _advisory_added(data, "verificationShapeFindings") if item["rule"] == "production-shaped-proof"] == []
 
 
+def test_delta_reporting_resolved_security_advisory() -> None:
+    with repo_fixture() as repo:
+        target = repo / "src" / "secrets.py"
+        target.write_text("TOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
+        git(repo, "add", "src/secrets.py")
+        git(repo, "commit", "-m", "base secret")
+        target.write_text("TOKEN = 'public'\n", encoding="utf-8")
+        code, data = check_json(repo)
+        group = data["securityAssumptionFindings"]
+        assert code == 0, data
+        assert len(group["resolved"]) == 1
+        assert group["resolved"][0]["rule"] == "sensitive-input"
+
+
+def test_delta_reporting_improved_security_advisory() -> None:
+    with repo_fixture() as repo:
+        target = repo / "src" / "secrets.py"
+        target.write_text("TOKEN = os.getenv('API_KEY')\nKEY = open('/home/me/.ssh/id_rsa').read()\n", encoding="utf-8")
+        git(repo, "add", "src/secrets.py")
+        git(repo, "commit", "-m", "base secrets")
+        target.write_text("TOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
+        code, data = check_json(repo)
+        improved = data["securityAssumptionFindings"]["improved"]
+        assert code == 0, data
+        assert len(improved) == 1
+        assert improved[0]["line"] == 0
+        assert improved[0]["evidence"] == "2 -> 1"
+
+
+def test_delta_reporting_worsened_security_advisory() -> None:
+    with repo_fixture() as repo:
+        target = repo / "src" / "secrets.py"
+        target.write_text("TOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
+        git(repo, "add", "src/secrets.py")
+        git(repo, "commit", "-m", "base secret")
+        target.write_text("TOKEN = os.getenv('API_KEY')\nKEY = open('/home/me/.ssh/id_rsa').read()\n", encoding="utf-8")
+        code, data = check_json(repo)
+        group = data["securityAssumptionFindings"]
+        assert code == 0, data
+        assert len(group["added"]) == 1
+        assert len(group["worsened"]) == 1
+        assert group["worsened"][0]["line"] == 0
+        assert group["worsened"][0]["evidence"] == "1 -> 2"
+
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1831,6 +1876,9 @@ TESTS = [
     test_production_shaped_proof_warns_on_mock_heavy_weak_test,
     test_production_shaped_proof_pytest_fixture_name_does_not_exempt_weak_mock_test,
     test_production_shaped_proof_allows_entrypoint_fixture_and_assertion_rich_tests,
+    test_delta_reporting_resolved_security_advisory,
+    test_delta_reporting_improved_security_advisory,
+    test_delta_reporting_worsened_security_advisory,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -751,7 +751,7 @@ def test_delta_reporting_resolved_security_advisory() -> None:
         target = repo / "src" / "secrets.py"
         target.write_text("TOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
         git(repo, "add", "src/secrets.py")
-        git(repo, "commit", "-m", "base secret")
+        git(repo, "commit", "--no-gpg-sign", "-m", "base secret")
         target.write_text("TOKEN = 'public'\n", encoding="utf-8")
         code, data = check_json(repo)
         group = data["securityAssumptionFindings"]
@@ -765,7 +765,7 @@ def test_delta_reporting_improved_security_advisory() -> None:
         target = repo / "src" / "secrets.py"
         target.write_text("TOKEN = os.getenv('API_KEY')\nKEY = open('/home/me/.ssh/id_rsa').read()\n", encoding="utf-8")
         git(repo, "add", "src/secrets.py")
-        git(repo, "commit", "-m", "base secrets")
+        git(repo, "commit", "--no-gpg-sign", "-m", "base secrets")
         target.write_text("TOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
         code, data = check_json(repo)
         improved = data["securityAssumptionFindings"]["improved"]
@@ -780,7 +780,7 @@ def test_delta_reporting_worsened_security_advisory() -> None:
         target = repo / "src" / "secrets.py"
         target.write_text("TOKEN = os.getenv('API_KEY')\n", encoding="utf-8")
         git(repo, "add", "src/secrets.py")
-        git(repo, "commit", "-m", "base secret")
+        git(repo, "commit", "--no-gpg-sign", "-m", "base secret")
         target.write_text("TOKEN = os.getenv('API_KEY')\nKEY = open('/home/me/.ssh/id_rsa').read()\n", encoding="utf-8")
         code, data = check_json(repo)
         group = data["securityAssumptionFindings"]

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -791,6 +791,38 @@ def test_delta_reporting_worsened_security_advisory() -> None:
         assert group["worsened"][0]["evidence"] == "1 -> 2"
 
 
+def test_delta_reporting_resolved_slop_shape_advisory() -> None:
+    with repo_fixture() as repo:
+        target = repo / "src" / "client.ts"
+        target.write_text("export const load = () => fetch('/x').catch(() => null);\n", encoding="utf-8")
+        git(repo, "add", "src/client.ts")
+        git(repo, "commit", "--no-gpg-sign", "-m", "base failure contract")
+        target.write_text("export const load = () => fetch('/x').catch(error => { throw error; });\n", encoding="utf-8")
+        code, data = check_json(repo)
+        resolved = data["slopShapeFindings"]["resolved"]
+        assert code == 0, data
+        assert len(resolved) == 1
+        assert resolved[0]["rule"] == "failure-contract-cheap-default"
+
+
+def test_delta_reporting_verification_shape_line_drift_is_not_resolved() -> None:
+    with repo_fixture() as repo:
+        target = repo / "tests" / "test_fake_surface.py"
+        body = "from unittest.mock import MagicMock\n\n" + "\n".join(
+            f"mock_{idx} = MagicMock()" for idx in range(16)
+        ) + "\n\ndef test_fake_surface():\n    result = mock_1()\n    assert result is not None\n"
+        target.write_text(body, encoding="utf-8")
+        git(repo, "add", "tests/test_fake_surface.py")
+        git(repo, "commit", "--no-gpg-sign", "-m", "base weak proof")
+        target.write_text("extra = object()\n" + body, encoding="utf-8")
+        code, data = check_json(repo)
+        group = data["verificationShapeFindings"]
+        assert code == 0, data
+        assert group["resolved"] == []
+        assert group["improved"] == []
+        assert group["worsened"] == []
+
+
 def test_declare_rejects_code_contract_without_preflight() -> None:
     with repo_fixture() as repo:
         result = run_gate(
@@ -1879,6 +1911,8 @@ TESTS = [
     test_delta_reporting_resolved_security_advisory,
     test_delta_reporting_improved_security_advisory,
     test_delta_reporting_worsened_security_advisory,
+    test_delta_reporting_resolved_slop_shape_advisory,
+    test_delta_reporting_verification_shape_line_drift_is_not_resolved,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,


### PR DESCRIPTION
# 06_PR6_delta_reporting

Problem:
Agents need to see whether advisory shapes were added, resolved, improved, or worsened.

Named failure mode:
advisory output lacks touched-file movement buckets

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, lean-code skill docs, supplied V1.3 plan, and reward spec scope where applicable. Supplied archive did not contain calibration/HANDOVER.md or calibration/analysis/COHORT_TABLE.md, so no current-corpus rerun is claimed.

Exact scope:
Touched-file base/current snapshots for advisory families only; no whole-repo scoring.

Existing surfaces touched:
P0 buckets; collect_scope(); read_git_file(); run_quality_gate(); advisory detector helpers.

Files changed:
.agent/lean/lean_code_gate.py, METHODOLOGY.md, tests/test_lean_code_gate.py

Prerequisites:
00_PR0_P0_advisory_surface, 01_PR1_sensitive_input, 02_PR2_failure_contract, 03_PR3_wrapper_value, 04_PR4_verification_mode, 05_PR5_production_shaped_proof

Net lean_code_gate.py lines added:
+80 / -0

Total patch size:
+163 / -0

Helpers reused:
read_git_file(), read_file(), scanner line helpers, advisory delta keying

Helpers added:
apply_advisory_delta(), advisory_snapshot_findings(), add_advisory_delta(), advisory_delta_key(), advisory_resolved_key(), advisory_count_key(), base_count_keys(), advisory_delta_summary()

Why existing helpers were insufficient:
Existing legacy checks are blocker-oriented and do not compute advisory movement. Current main no longer has unique_advisory_findings(), so snapshot dedupe is kept inline through advisory_delta_key(). Reviewer feedback required stable resolved identity for count-derived production-shaped-proof findings.

Deletion/consolidation attempted:
Used count summaries for worsened/improved to avoid fake sample attribution. Did not mask runtime growth with unrelated formatting compression.

Chosen path:
Cheap exact resolved findings plus per-rule/family/path/severity count movement. Production-shaped-proof resolved identity omits line and count-derived evidence so unchanged logical findings are not falsely resolved by line/count drift.

Rejected simpler paths:
Whole-repo PR-time scoring, findingCounts backfill, fake sample=current[0] precision, and dropping line/evidence from all advisory resolved keys.

Compatibility impact:
Additive buckets only; no legacy output or blocker behavior change.

Verification:
- Focused delta tests for security resolved/improved/worsened, slop resolved, and verification line/count drift passed.
- `cd lean-code-gate-v3 && PYTHONDONTWRITEBYTECODE=1 python3 -B -S tests/test_lean_code_gate.py` passed 90 tests.
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S -m py_compile lean-code-gate-v3/.agent/lean/lean_code_gate.py lean-code-gate-v3/tests/test_lean_code_gate.py` passed.
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S lean-code-gate-v3/.agent/lean/lean_code_gate.py check --repo "$PWD" --json` passed.
- `git diff --check` passed.

Known check result:
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S /home/prop_/.codex/skills/production-code/scripts/code_quality_gate.py check --repo "$PWD" --base-ref origin/main` fails only on the expected creator-slice runtime growth: `large source file lean-code-gate-v3/.agent/lean/lean_code_gate.py must shrink when touched (2754 >= 2674)`. No duplication, cleanup, temp artifact, reuse, or quality escape issue was reported.

Calibration rule:
Movement buckets inform calibration but do not replace per-rule attribution.

Rollback path:
Remove delta helpers and call; P0 bucket names remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Touched-file advisory findings now include resolved, improved, and worsened deltas versus baseline with per-finding count tracking and deduplication to highlight trend changes.

* **Documentation**
  * Methodology clarifies delta categories, their intent for reviewer calibration, and that they don’t affect gate exit, legacy warnings, or hard-rule behavior.

* **Tests**
  * Added end-to-end tests covering resolved/improved/worsened delta reporting across commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->