### PR TITLE
P7: add default-off reward telemetry

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -2270,7 +2270,10 @@ def reward_telemetry_event(root: Path, current_contract: dict[str, object], fina
 def maybe_log_reward_telemetry(root: Path, current_contract: dict[str, object], active_policy: dict[str, object], final_error_count: int, quality: dict[str, object] | None) -> None:
     if not active_policy.get("reward_telemetry_enabled") or not current_contract or quality is None:
         return
-    log_event(root, reward_telemetry_event(root, current_contract, final_error_count, quality))
+    try:
+        log_event(root, reward_telemetry_event(root, current_contract, final_error_count, quality))
+    except OSError:
+        return
 
 
 def format_quality_text(result: dict[str, object]) -> str:

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -47,6 +47,7 @@ DEFAULT_POLICY: dict[str, object] = {
     "block_hidden_bash_writes": True,
     "run_quality_gate_on_stop": True,
     "fail_on_quality_warnings": False,
+    "reward_telemetry_enabled": False,
     # max_design_markers: 4 (was 2): requires all 4 DESIGN_RE categories to
     # match. Calibrated against Pydantic's _generate_schema.py (2922 lines,
     # density 1.4/100, was firing as FP). Combined with density gating >= 3.0
@@ -2239,6 +2240,39 @@ def format_advisory_sample(finding: dict[str, object]) -> str:
     return f"- {severity} {rule} at {location}: {message}"
 
 
+def advisory_bucket_counts(quality: dict[str, object]) -> dict[str, dict[str, int]]:
+    counts: dict[str, dict[str, int]] = {}
+    for group_name in ADVISORY_GROUP_NAMES:
+        group = quality.get(group_name)
+        counts[group_name] = {bucket: len(group.get(bucket, [])) if isinstance(group, dict) and isinstance(group.get(bucket), list) else 0 for bucket in ADVISORY_BUCKET_NAMES}
+    return counts
+
+
+def reward_telemetry_event(root: Path, current_contract: dict[str, object], final_error_count: int, quality: dict[str, object]) -> dict[str, object]:
+    delta_value = delta(root, current_contract)
+    quality_errors = quality.get("errors") if isinstance(quality.get("errors"), list) else []
+    quality_warnings = quality.get("warnings") if isinstance(quality.get("warnings"), list) else []
+    files = delta_value.get("files") if isinstance(delta_value.get("files"), list) else []
+    return {
+        "event": "reward_telemetry",
+        "quality_ok": bool(quality.get("ok")),
+        "final_error_count": final_error_count,
+        "quality_error_count": len(quality_errors),
+        "quality_warning_count": len(quality_warnings),
+        "advisory_counts": advisory_bucket_counts(quality),
+        "changed_files_count": len(files),
+        "added": int(delta_value.get("added") or 0),
+        "deleted": int(delta_value.get("deleted") or 0),
+        "changed": int(delta_value.get("changed") or 0),
+    }
+
+
+def maybe_log_reward_telemetry(root: Path, current_contract: dict[str, object], active_policy: dict[str, object], final_error_count: int, quality: dict[str, object] | None) -> None:
+    if not active_policy.get("reward_telemetry_enabled") or not current_contract or quality is None:
+        return
+    log_event(root, reward_telemetry_event(root, current_contract, final_error_count, quality))
+
+
 def format_quality_text(result: dict[str, object]) -> str:
     lines = [
         "Lean Code Quality Gate",
@@ -2620,11 +2654,13 @@ def stop(payload: dict[str, object]) -> None:
         current_contract = contract(root)
         active_policy = policy(root)
         errors = final_errors(root, current_contract, active_policy)
+        quality: dict[str, object] | None = None
         if active_policy["run_quality_gate_on_stop"]:
             fail_warnings = bool(active_policy["fail_on_quality_warnings"]) and not (current_contract or {}).get("allow_quality_warnings")
             quality = run_quality_gate(root, str((current_contract or {}).get("base_ref") or "") or None, fail_warnings)
             if not quality["ok"]:
                 errors.extend(["Quality gate failed: " + error for error in quality["errors"]])
+        maybe_log_reward_telemetry(root, current_contract, active_policy, len(errors), quality)
         all_errors.extend(f"{root}: {error}" if len(roots) > 1 else error for error in errors)
     if all_errors:
         deny(

--- a/lean-code-gate-v3/.agent/lean/policy.json
+++ b/lean-code-gate-v3/.agent/lean/policy.json
@@ -18,6 +18,7 @@
   "block_hidden_bash_writes": true,
   "run_quality_gate_on_stop": true,
   "fail_on_quality_warnings": false,
+  "reward_telemetry_enabled": false,
   "max_design_markers": 4,
   "max_design_marker_density_per_100_lines": 3.0,
   "allowed_broad_globs": ["src/**", "lib/**", "app/**", "tests/**", "test/**"],

--- a/lean-code-gate-v3/METHODOLOGY.md
+++ b/lean-code-gate-v3/METHODOLOGY.md
@@ -87,6 +87,8 @@ The final quality gate inspects the changed source scope and fails on:
 The advisory surface also reports sensitive-input reads when changed code touches environment values, credential paths, keyrings, auth/cookie headers, private key material, or git remote URLs. It reports stronger evidence when the same touched area logs, serializes, caches, snapshots, or emits that value. TypeScript and JavaScript catch/reject paths are advisory findings when they only log, stringify unknown errors, or return cheap defaults such as `null`, `undefined`, `false`, empty arrays, empty objects, or empty strings. One-body forwarding wrappers are advisory findings when no validation, normalization, instrumentation, retry, compatibility, deprecation, or boundary value is visible nearby. Full non-minimal code work also reports an advisory when `proof_plan` omits a named verification loop such as `red-green-refactor`, `green-refactor-green`, or `smoke-check`. Large mock-heavy tests with weak assertions and no visible production entrypoint are advisory proof-shape findings.
 Advisory findings are bucketed as added, resolved, improved, or worsened for touched files only. Delta buckets are reviewer ergonomics and calibration inputs; they are not blocker attribution and do not change legacy warnings, hard rules, or exit behavior.
 
+Reward telemetry is default-off. When `reward_telemetry_enabled` is true, Stop appends aggregate `reward_telemetry` events only; it does not score, challenge, expose weights, or log raw contract text.
+
 Warnings are emitted for moderate bloat and weaker reuse signals. Projects can promote warnings to failures in `.agent/lean/policy.json`.
 
 ## Operating guidance

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -161,6 +161,13 @@ def snapshot_paths(repo: Path) -> set[str]:
     return {str(path.relative_to(repo)) for path in repo.rglob("*") if ".git" not in path.relative_to(repo).parts}
 
 
+def reward_events(repo: Path) -> list[dict[str, object]]:
+    path = repo / ".agent" / "lean" / "state" / "events.jsonl"
+    if not path.exists():
+        return []
+    return [item for item in (json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()) if item.get("event") == "reward_telemetry"]
+
+
 
 def test_p0_advisory_groups_are_empty_and_compatible() -> None:
     with repo_fixture() as repo:
@@ -821,6 +828,54 @@ def test_delta_reporting_verification_shape_line_drift_is_not_resolved() -> None
         assert group["resolved"] == []
         assert group["improved"] == []
         assert group["worsened"] == []
+
+
+def test_reward_telemetry_disabled_by_default() -> None:
+    with repo_fixture() as repo:
+        declare_valid(repo)
+        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b + 0\n", encoding="utf-8")
+        run_gate(repo, "posttool", payload={"cwd": str(repo), "tool_name": "Bash", "tool_input": {"command": "pytest tests/test_app.py"}, "tool_response": {"exit_code": 0}})
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop"})
+        assert result.returncode == 0, result.stdout
+        assert reward_events(repo) == []
+
+
+def test_reward_telemetry_enabled_logs_aggregate_shape_only() -> None:
+    with repo_fixture() as repo:
+        (repo / ".agent" / "lean" / "policy.json").write_text(json.dumps({"reward_telemetry_enabled": True}), encoding="utf-8")
+        git(repo, "add", ".agent/lean/policy.json")
+        git(repo, "commit", "--no-gpg-sign", "-m", "enable telemetry")
+        declare_valid(repo)
+        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b + 0\n", encoding="utf-8")
+        run_gate(repo, "posttool", payload={"cwd": str(repo), "tool_name": "Bash", "tool_input": {"command": "pytest tests/test_app.py"}, "tool_response": {"exit_code": 0}})
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop"})
+        assert result.returncode == 0, result.stdout
+        events = reward_events(repo)
+        assert len(events) == 1
+        event = events[0]
+        assert event["quality_ok"] is True
+        assert event["final_error_count"] == 0
+        assert event["quality_error_count"] == 0
+        assert event["changed_files_count"] >= 1
+        assert set(event["advisory_counts"]) == {"securityAssumptionFindings", "slopShapeFindings", "verificationShapeFindings"}
+        assert not {"score", "verdict", "critique", "contract", "contract_id", "challenge", "leaderboard"} & set(event)
+        assert "src/app.py" not in json.dumps(event, sort_keys=True)
+
+
+def test_reward_telemetry_skips_when_quality_gate_disabled() -> None:
+    with repo_fixture() as repo:
+        (repo / ".agent" / "lean" / "policy.json").write_text(
+            json.dumps({"reward_telemetry_enabled": True, "run_quality_gate_on_stop": False}),
+            encoding="utf-8",
+        )
+        git(repo, "add", ".agent/lean/policy.json")
+        git(repo, "commit", "--no-gpg-sign", "-m", "disable quality telemetry")
+        declare_valid(repo)
+        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b + 0\n", encoding="utf-8")
+        run_gate(repo, "posttool", payload={"cwd": str(repo), "tool_name": "Bash", "tool_input": {"command": "pytest tests/test_app.py"}, "tool_response": {"exit_code": 0}})
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop"})
+        assert result.returncode == 0, result.stdout
+        assert reward_events(repo) == []
 
 
 def test_declare_rejects_code_contract_without_preflight() -> None:
@@ -1913,6 +1968,9 @@ TESTS = [
     test_delta_reporting_worsened_security_advisory,
     test_delta_reporting_resolved_slop_shape_advisory,
     test_delta_reporting_verification_shape_line_drift_is_not_resolved,
+    test_reward_telemetry_disabled_by_default,
+    test_reward_telemetry_enabled_logs_aggregate_shape_only,
+    test_reward_telemetry_skips_when_quality_gate_disabled,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,
     test_unknown_task_type_is_rejected_instead_of_forcing_full_preflight,

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -862,6 +862,20 @@ def test_reward_telemetry_enabled_logs_aggregate_shape_only() -> None:
         assert "src/app.py" not in json.dumps(event, sort_keys=True)
 
 
+def test_reward_telemetry_append_failure_does_not_break_stop() -> None:
+    with repo_fixture() as repo:
+        (repo / ".agent" / "lean" / "policy.json").write_text(json.dumps({"reward_telemetry_enabled": True}), encoding="utf-8")
+        git(repo, "add", ".agent/lean/policy.json")
+        git(repo, "commit", "--no-gpg-sign", "-m", "enable telemetry")
+        declare_valid(repo)
+        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b + 0\n", encoding="utf-8")
+        run_gate(repo, "posttool", payload={"cwd": str(repo), "tool_name": "Bash", "tool_input": {"command": "pytest tests/test_app.py"}, "tool_response": {"exit_code": 0}})
+        event_log = repo / ".agent" / "lean" / "state" / "events.jsonl"
+        event_log.chmod(0o400)
+        result = run_gate(repo, "stop", payload={"cwd": str(repo), "hook_event_name": "Stop"})
+        assert result.returncode == 0, result.stderr
+
+
 def test_reward_telemetry_skips_when_quality_gate_disabled() -> None:
     with repo_fixture() as repo:
         (repo / ".agent" / "lean" / "policy.json").write_text(
@@ -1970,6 +1984,7 @@ TESTS = [
     test_delta_reporting_verification_shape_line_drift_is_not_resolved,
     test_reward_telemetry_disabled_by_default,
     test_reward_telemetry_enabled_logs_aggregate_shape_only,
+    test_reward_telemetry_append_failure_does_not_break_stop,
     test_reward_telemetry_skips_when_quality_gate_disabled,
     test_declare_rejects_code_contract_without_preflight,
     test_minimal_preflight_allows_micro_bugfix_without_cargo_fields,


### PR DESCRIPTION
# 07_PR7_reward_telemetry

Problem:
Agents only learn from blockers, but reward scoring is not calibrated enough to ship.

Named failure mode:
need observational reward telemetry without scoring/challenge surface

Required reading completed:
Relevant lean_code_gate.py function group, policy.json, tests/test_lean_code_gate.py, METHODOLOGY.md, lean-code skill docs, supplied V1.3 plan, and reward spec scope where applicable. Supplied archive did not contain calibration/HANDOVER.md or calibration/analysis/COHORT_TABLE.md, so no current-corpus rerun is claimed.

Exact scope:
Default-off aggregate Stop event only when quality gate runs; no scoring, challenge, leaderboard, chain, badge, or raw contract logging.

Existing surfaces touched:
policy.json; log_event(); stop(); delta(); run_quality_gate() output.

Files changed:
.agent/lean/lean_code_gate.py, .agent/lean/policy.json, METHODOLOGY.md, tests/test_lean_code_gate.py

Prerequisites:
00_PR0_P0_advisory_surface, 01_PR1_sensitive_input, 02_PR2_failure_contract, 03_PR3_wrapper_value, 04_PR4_verification_mode, 05_PR5_production_shaped_proof, 06_PR6_delta_reporting

Net lean_code_gate.py lines added:
+39 / -0

Total patch size:
+115 / -0

Helpers reused:
log_event(), delta(), ADVISORY_GROUP_NAMES, ADVISORY_BUCKET_NAMES

Helpers added:
advisory_bucket_counts(), reward_telemetry_event(), maybe_log_reward_telemetry()

Why existing helpers were insufficient:
Existing events do not record aggregate advisory/quality shape; reward layer is not calibrated for scoring.

Deletion/consolidation attempted:
Telemetry-only key `reward_telemetry_enabled`; no challenge fields or identity surface.

Chosen path:
Single default-off aggregate event after final errors include quality errors. Optional telemetry append failures are isolated so stop pass/block behavior remains structured and authoritative.

Rejected simpler paths:
Score/verdict/critique, leaderboard, challenge, event chain, contract id, raw contract logging, second quality run, and quality-fail-only telemetry that conflicts with the creator P7 enabled clean-run fixture.

Compatibility impact:
Disabled by default. When enabled, appends event only; no CLI/hook semantics change.

Verification:
- Focused reward telemetry tests passed: disabled default, enabled aggregate shape-only event, append failure does not break stop, skip when quality gate disabled, and no repo artifacts from `check`.
- `cd lean-code-gate-v3 && PYTHONDONTWRITEBYTECODE=1 python3 -B -S tests/test_lean_code_gate.py` passed 94 tests.
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S -m py_compile lean-code-gate-v3/.agent/lean/lean_code_gate.py lean-code-gate-v3/tests/test_lean_code_gate.py` passed.
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S lean-code-gate-v3/.agent/lean/lean_code_gate.py check --repo "$PWD" --json` passed.
- `git diff --check` passed.

Known check result:
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S /home/prop_/.codex/skills/production-code/scripts/code_quality_gate.py check --repo "$PWD" --base-ref origin/main` fails only on the expected creator-slice runtime growth: `large source file lean-code-gate-v3/.agent/lean/lean_code_gate.py must shrink when touched (2793 >= 2754)`. No duplication, cleanup, temp artifact, reuse, or quality escape issue was reported.

Calibration rule:
Scoring/challenge deferred until P1-P3 calibration clears duplicate-block FP baseline.

Rollback path:
Remove policy key/helpers/stop call/docs/tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional reward telemetry logging to emit aggregate quality-gate metrics (disabled by default).

* **Documentation**
  * Clarified telemetry behavior and explicit data-privacy limits in methodology docs.

* **Tests**
  * Added tests covering telemetry enabled/disabled cases, event shape-only assertions, skip conditions, and lifecycle behavior.

* **Bug Fixes**
  * Telemetry write failures are now ignored so they do not break the stop flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->