### PR TITLE
[codex] Bump Lean Gate runtime version

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Lean Code Gate v3.
-
+"""Lean Code Gate v3.1.
 Deterministic contract, scope, verification, and changed-code quality gates for
 coding agents. The script is intentionally dependency-free so hooks can run in a
 fresh repository without importing project packages.
@@ -23,7 +22,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-VERSION = "3.0.0"
+VERSION = "3.1.0"
 STATE_DIR = ".agent/lean/state"
 POLICY_FILE = ".agent/lean/policy.json"
 


### PR DESCRIPTION
## Summary

Bumps the Lean Code Gate runtime metadata from `3.0.0` to `3.1.0` after the P0-P7 rollout.

This updates the module header and the `VERSION` constant only. Runtime behavior is unchanged.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S /home/prop_/.codex/lean-code-gate-v3/lean_code_gate.py check --repo "$PWD" --base-ref origin/main --json`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S /home/prop_/.codex/skills/production-code/scripts/code_quality_gate.py check --repo "$PWD" --base-ref origin/main`

Both passed. The installed runtime reports `"version": "3.1.0"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated tool version to v3.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->