### PR TITLE
Fix Stop hook root resolution timeout

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -793,9 +793,26 @@ def emit(value: dict[str, object]) -> None:
 
 def deny(event: str, reason: str) -> None:
     if event == "PreToolUse":
-        emit({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}, "decision": "block", "reason": reason})
+        emit(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                },
+                "decision": "block",
+                "reason": reason,
+            }
+        )
     elif event == "PermissionRequest":
-        emit({"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": "deny", "message": reason}}})
+        emit(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PermissionRequest",
+                    "decision": {"behavior": "deny", "message": reason},
+                }
+            }
+        )
     else:
         emit({"decision": "block", "reason": reason})
 
@@ -811,9 +828,11 @@ def command_hint(root: Path | None = None) -> str:
 def context(event: str) -> None:
     message = (
         "Lean Code Gate v3 active. Inspect first, then declare the smallest Lean Change Contract before mutating files. "
-        f"Micro-fix form: `{command_hint()} declare --minimal-preflight --intent \"...\" --scope \"file1,file2\" --task-type bugfix --verify \"pytest path/to/test.py\"`. "
-        "Full production form adds --affected-surface, --authoritative-contract, --invariant, --reuse-path or --no-reuse-reason, --proof-plan, and --risk-check. "
-        "Stop runs the quality gate: no fake-green suppressions, duplicate blocks, high-confidence helper reimplementation, temp artifacts, or bloat."
+        f"Micro-fix form: `{command_hint()} declare "
+        "--minimal-preflight --intent \"...\" --scope \"file1,file2\" --task-type bugfix --verify \"pytest path/to/test.py\"`. "
+        "Full production form adds --affected-surface, --authoritative-contract, --invariant, --reuse-path or --no-reuse-reason, "
+        "--proof-plan, and --risk-check. Stop runs the quality gate: no fake-green suppressions, duplicate blocks, "
+        "high-confidence helper reimplementation, temp artifacts, or bloat."
     )
     emit({"hookSpecificOutput": {"hookEventName": event, "additionalContext": message}})
 

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -640,13 +640,12 @@ def hook_root(payload: dict[str, object], tool: str, tool_input: dict[str, objec
 
 def stop_roots(payload: dict[str, object]) -> list[Path]:
     root = repo_root(str(payload.get("cwd") or "") or None)
-    nested = nested_git_roots(root)
-    if not nested:
+    if git_toplevel(root) == root:
         return [root]
     target = active_state(root).get("target_root")
     if isinstance(target, str) and (found := git_toplevel(Path(target).expanduser().resolve())) is not None and found != root and root in found.parents:
         return [found]
-    return [root] if git_toplevel(root) == root else []
+    return []
 
 
 def remember_target_root(payload: dict[str, object], root: Path) -> None:

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -640,12 +640,10 @@ def hook_root(payload: dict[str, object], tool: str, tool_input: dict[str, objec
 
 def stop_roots(payload: dict[str, object]) -> list[Path]:
     root = repo_root(str(payload.get("cwd") or "") or None)
-    if git_toplevel(root) == root:
-        return [root]
     target = active_state(root).get("target_root")
     if isinstance(target, str) and (found := git_toplevel(Path(target).expanduser().resolve())) is not None and found != root and root in found.parents:
         return [found]
-    return []
+    return [root] if git_toplevel(root) == root else []
 
 
 def remember_target_root(payload: dict[str, object], root: Path) -> None:

--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -617,16 +617,19 @@ def hook_root(payload: dict[str, object], tool: str, tool_input: dict[str, objec
 
     if is_mutating:
         path_roots: set[Path] = set()
-        for value in facts(root, tool, tool_input).get("paths", []):
+        path_values = facts(root, tool, tool_input).get("paths", [])
+        for value in path_values:
             if isinstance(value, str):
                 path = (root / value).resolve()
                 found = git_toplevel(path if path.is_dir() else path.parent)
-                if found is not None and found != root and root in found.parents:
+                if found is not None and (found == root or root in found.parents):
                     path_roots.add(found)
         if len(path_roots) == 1:
             return next(iter(path_roots))
         if len(path_roots) > 1:
             raise ValueError("Lean Code Gate could not choose between nested target repos: " + ", ".join(str(path) for path in sorted(path_roots)))
+        if not path_values and (target := remembered_target_root(root)) is not None:
+            return target
 
     if nested_git_roots(root):
         raise ValueError(
@@ -640,9 +643,8 @@ def hook_root(payload: dict[str, object], tool: str, tool_input: dict[str, objec
 
 def stop_roots(payload: dict[str, object]) -> list[Path]:
     root = repo_root(str(payload.get("cwd") or "") or None)
-    target = active_state(root).get("target_root")
-    if isinstance(target, str) and (found := git_toplevel(Path(target).expanduser().resolve())) is not None and found != root and root in found.parents:
-        return [found]
+    if (target := remembered_target_root(root)) is not None:
+        return [target]
     return [root] if git_toplevel(root) == root else []
 
 
@@ -728,6 +730,13 @@ def active_state(root: Path) -> dict[str, object]:
     return loaded if isinstance(loaded, dict) else {}
 
 
+def remembered_target_root(controller: Path) -> Path | None:
+    target = active_state(controller).get("target_root")
+    if isinstance(target, str) and (found := git_toplevel(Path(target).expanduser().resolve())) is not None and found != controller and controller in found.parents:
+        return found
+    return None
+
+
 def contract_path(root: Path) -> Path:
     return state_dir(root) / "contract.json"
 
@@ -784,26 +793,9 @@ def emit(value: dict[str, object]) -> None:
 
 def deny(event: str, reason: str) -> None:
     if event == "PreToolUse":
-        emit(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": reason,
-                },
-                "decision": "block",
-                "reason": reason,
-            }
-        )
+        emit({"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": reason}, "decision": "block", "reason": reason})
     elif event == "PermissionRequest":
-        emit(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PermissionRequest",
-                    "decision": {"behavior": "deny", "message": reason},
-                }
-            }
-        )
+        emit({"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": "deny", "message": reason}}})
     else:
         emit({"decision": "block", "reason": reason})
 
@@ -819,11 +811,9 @@ def command_hint(root: Path | None = None) -> str:
 def context(event: str) -> None:
     message = (
         "Lean Code Gate v3 active. Inspect first, then declare the smallest Lean Change Contract before mutating files. "
-        f"Micro-fix form: `{command_hint()} declare "
-        "--minimal-preflight --intent \"...\" --scope \"file1,file2\" --task-type bugfix --verify \"pytest path/to/test.py\"`. "
-        "Full production form adds --affected-surface, --authoritative-contract, --invariant, --reuse-path or --no-reuse-reason, "
-        "--proof-plan, and --risk-check. Stop runs the quality gate: no fake-green suppressions, duplicate blocks, "
-        "high-confidence helper reimplementation, temp artifacts, or bloat."
+        f"Micro-fix form: `{command_hint()} declare --minimal-preflight --intent \"...\" --scope \"file1,file2\" --task-type bugfix --verify \"pytest path/to/test.py\"`. "
+        "Full production form adds --affected-surface, --authoritative-contract, --invariant, --reuse-path or --no-reuse-reason, --proof-plan, and --risk-check. "
+        "Stop runs the quality gate: no fake-green suppressions, duplicate blocks, high-confidence helper reimplementation, temp artifacts, or bloat."
     )
     emit({"hookSpecificOutput": {"hookEventName": event, "additionalContext": message}})
 
@@ -2506,7 +2496,9 @@ def user_prompt(payload: dict[str, object]) -> None:
     root = repo_root(str(payload.get("cwd") or "") or None)
     prompt_hash = hashlib.sha256(str(payload.get("prompt") or "").encode()).hexdigest()[:16]
     old = contract(root)
-    write_json(active_path(root), {"session_id": payload.get("session_id"), "turn_id": payload.get("turn_id"), "prompt_hash": prompt_hash, "at": time.time()})
+    active = active_state(root) if active_state(root).get("session_id") == payload.get("session_id") else {}
+    active.update({"session_id": payload.get("session_id"), "turn_id": payload.get("turn_id"), "prompt_hash": prompt_hash, "at": time.time()})
+    write_json(active_path(root), active)
     if old and old.get("prompt_hash") != prompt_hash:
         write_json(state_dir(root) / "previous_contract.json", old)
         contract_path(root).unlink(missing_ok=True)
@@ -2515,7 +2507,9 @@ def user_prompt(payload: dict[str, object]) -> None:
 
 def session_start(payload: dict[str, object]) -> None:
     root = repo_root(str(payload.get("cwd") or "") or None)
-    write_json(active_path(root), {"session_id": payload.get("session_id"), "turn_id": payload.get("turn_id"), "at": time.time()})
+    active = active_state(root) if active_state(root).get("session_id") == payload.get("session_id") else {}
+    active.update({"session_id": payload.get("session_id"), "turn_id": payload.get("turn_id"), "at": time.time()})
+    write_json(active_path(root), active)
     context(str(payload.get("hook_event_name") or "SessionStart"))
 
 

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -1110,6 +1110,45 @@ def test_stop_from_controller_checks_nested_repo_without_tool_workdir() -> None:
         assert result.stdout == ""
 
 
+def test_stop_from_git_controller_prefers_remembered_nested_target() -> None:
+    with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
+        controller = Path(tmp)
+        git(controller, "init")
+        git(controller, "config", "user.email", "test@example.com")
+        git(controller, "config", "user.name", "Test User")
+        (controller / ".gitignore").write_text(".agent/\nnested/\n", encoding="utf-8")
+        (controller / "README.md").write_text("outer repo\n", encoding="utf-8")
+        git(controller, "add", ".")
+        git(controller, "commit", "--no-gpg-sign", "-m", "init")
+        nested = controller / "nested"
+        init_repo_fixture(nested)
+        declare_minimal(nested)
+
+        result = run_gate(
+            controller,
+            "pretool",
+            payload={
+                "cwd": str(controller),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": str(nested / "src" / "app.py"),
+                    "old_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                    "new_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                },
+            },
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+        (nested / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a - b\n", encoding="utf-8")
+        result = run_gate(controller, "stop", payload={"cwd": str(controller), "hook_event_name": "Stop"})
+
+        data = json.loads(result.stdout)
+        assert data["decision"] == "block"
+        assert "Declared verification has not passed" in data["reason"]
+
+
 def test_stop_from_controller_ignores_untargeted_dirty_nested_repo() -> None:
     with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
         controller = Path(tmp)
@@ -2023,6 +2062,7 @@ TESTS = [
     test_hook_resolves_nested_repo_from_changed_path_without_workdir,
     test_hook_fails_closed_when_controller_target_is_ambiguous,
     test_stop_from_controller_checks_nested_repo_without_tool_workdir,
+    test_stop_from_git_controller_prefers_remembered_nested_target,
     test_stop_from_controller_ignores_untargeted_dirty_nested_repo,
     test_stop_roots_non_git_controller_does_not_scan_nested_repos,
     test_repo_root_env_rejects_missing_target_repo,

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -1080,6 +1080,155 @@ def test_hook_fails_closed_when_controller_target_is_ambiguous() -> None:
         assert "No active Lean Change Contract" not in data["reason"]
 
 
+def test_pathless_bash_uses_remembered_target_and_still_blocks_hidden_write() -> None:
+    with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
+        controller = Path(tmp)
+        git(controller, "init")
+        git(controller, "config", "user.email", "test@example.com")
+        git(controller, "config", "user.name", "Test User")
+        (controller / ".gitignore").write_text(".agent/\nnested/\n", encoding="utf-8")
+        (controller / "README.md").write_text("outer repo\n", encoding="utf-8")
+        git(controller, "add", ".")
+        git(controller, "commit", "--no-gpg-sign", "-m", "init")
+        nested = controller / "nested"
+        init_repo_fixture(nested)
+        declare_minimal(nested)
+
+        result = run_gate(
+            controller,
+            "session-start",
+            payload={"cwd": str(controller), "hook_event_name": "SessionStart", "session_id": "s1", "turn_id": "t1"},
+        )
+        assert result.returncode == 0
+        result = run_gate(
+            controller,
+            "pretool",
+            payload={
+                "cwd": str(controller),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": str(nested / "src" / "app.py"),
+                    "old_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                    "new_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                },
+            },
+        )
+        assert result.returncode == 0
+        assert result.stdout == ""
+
+        result = run_gate(
+            controller,
+            "user-prompt",
+            payload={"cwd": str(controller), "hook_event_name": "UserPromptSubmit", "session_id": "s1", "turn_id": "t2", "prompt": "next"},
+        )
+        assert result.returncode == 0
+        result = run_gate(
+            controller,
+            "session-start",
+            payload={"cwd": str(controller), "hook_event_name": "SessionStart", "session_id": "s1", "turn_id": "t3"},
+        )
+        assert result.returncode == 0
+
+        result = run_gate(
+            controller,
+            "pretool",
+            payload={
+                "cwd": str(controller),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"cmd": "cp src/app.py src/app2.py"},
+            },
+        )
+
+        data = json.loads(result.stdout)
+        assert data["decision"] == "block"
+        assert "Hidden file-changing Bash blocked" in data["reason"]
+        assert "cannot resolve a unique target repo" not in data["reason"]
+
+
+def test_pathless_bash_ignores_stale_remembered_target() -> None:
+    with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
+        controller = Path(tmp) / "controller"
+        controller.mkdir()
+        git(controller, "init")
+        git(controller, "config", "user.email", "test@example.com")
+        git(controller, "config", "user.name", "Test User")
+        nested = controller / "nested"
+        stale = Path(tmp) / "outside"
+        init_repo_fixture(nested)
+        init_repo_fixture(stale)
+        active = controller / ".agent" / "lean" / "state" / "active.json"
+        active.parent.mkdir(parents=True)
+        active.write_text(json.dumps({"session_id": "s1", "target_root": str(stale)}), encoding="utf-8")
+
+        result = run_gate(
+            controller,
+            "pretool",
+            payload={
+                "cwd": str(controller),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"cmd": "cp src/app.py src/app2.py"},
+            },
+        )
+
+        data = json.loads(result.stdout)
+        assert data["decision"] == "block"
+        assert "cannot resolve a unique target repo" in data["reason"]
+
+
+def test_path_bearing_edit_uses_actual_nested_repo_over_remembered_target() -> None:
+    with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
+        controller = Path(tmp)
+        git(controller, "init")
+        git(controller, "config", "user.email", "test@example.com")
+        git(controller, "config", "user.name", "Test User")
+        first = controller / "first"
+        second = controller / "second"
+        init_repo_fixture(first)
+        init_repo_fixture(second)
+        declare_minimal(first)
+        declare_minimal(second)
+
+        result = run_gate(
+            controller,
+            "pretool",
+            payload={
+                "cwd": str(controller),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": str(first / "src" / "app.py"),
+                    "old_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                    "new_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                },
+            },
+        )
+        assert result.returncode == 0
+
+        before_first_events = (first / ".agent" / "lean" / "state" / "events.jsonl").read_text(encoding="utf-8")
+        result = run_gate(
+            controller,
+            "pretool",
+            payload={
+                "cwd": str(controller),
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": str(second / "src" / "app.py"),
+                    "old_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                    "new_string": "def add(a: int, b: int) -> int:\n    return a + b\n",
+                },
+            },
+        )
+
+        assert result.returncode == 0
+        assert result.stdout == ""
+        assert (first / ".agent" / "lean" / "state" / "events.jsonl").read_text(encoding="utf-8") == before_first_events
+        assert (second / ".agent" / "lean" / "state" / "events.jsonl").exists()
+
+
 def test_stop_from_controller_checks_nested_repo_without_tool_workdir() -> None:
     with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
         controller = Path(tmp)
@@ -2061,6 +2210,9 @@ TESTS = [
     test_repo_root_env_keeps_state_in_target_repo_from_controller_cwd,
     test_hook_resolves_nested_repo_from_changed_path_without_workdir,
     test_hook_fails_closed_when_controller_target_is_ambiguous,
+    test_pathless_bash_uses_remembered_target_and_still_blocks_hidden_write,
+    test_pathless_bash_ignores_stale_remembered_target,
+    test_path_bearing_edit_uses_actual_nested_repo_over_remembered_target,
     test_stop_from_controller_checks_nested_repo_without_tool_workdir,
     test_stop_from_git_controller_prefers_remembered_nested_target,
     test_stop_from_controller_ignores_untargeted_dirty_nested_repo,

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import shlex
 import shutil
 import subprocess
+import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
+from types import ModuleType
 from typing import Iterator
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -167,6 +170,18 @@ def reward_events(repo: Path) -> list[dict[str, object]]:
         return []
     return [item for item in (json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()) if item.get("event") == "reward_telemetry"]
 
+
+def load_gate_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("lean_code_gate_under_test", GATE)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+    return module
 
 
 def test_p0_advisory_groups_are_empty_and_compatible() -> None:
@@ -1110,6 +1125,20 @@ def test_stop_from_controller_ignores_untargeted_dirty_nested_repo() -> None:
         assert result.stdout == ""
 
 
+def test_stop_roots_non_git_controller_does_not_scan_nested_repos() -> None:
+    with tempfile.TemporaryDirectory(prefix="gate-controller-") as tmp:
+        controller = Path(tmp)
+        init_repo_fixture(controller / "nested")
+        gate = load_gate_module()
+
+        def fail_scan(root: Path) -> list[Path]:
+            raise AssertionError(f"unexpected nested repo scan under {root}")
+
+        gate.nested_git_roots = fail_scan
+
+        assert gate.stop_roots({"cwd": str(controller)}) == []
+
+
 def test_repo_root_env_rejects_missing_target_repo() -> None:
     with repo_fixture() as repo:
         missing = repo.parent / "missing-target"
@@ -1995,6 +2024,7 @@ TESTS = [
     test_hook_fails_closed_when_controller_target_is_ambiguous,
     test_stop_from_controller_checks_nested_repo_without_tool_workdir,
     test_stop_from_controller_ignores_untargeted_dirty_nested_repo,
+    test_stop_roots_non_git_controller_does_not_scan_nested_repos,
     test_repo_root_env_rejects_missing_target_repo,
     test_repo_root_env_rejects_non_git_target_repo,
     test_repo_identity_does_not_persist_origin_url_credentials,


### PR DESCRIPTION
## Summary
- Bound Lean Code Gate Stop root resolution to concrete git repo targets.
- Preserve full Stop quality gates for repo cwd and remembered nested target roots.
- No-op only when a controller cwd has no resolved git repo target, avoiding recursive home scans.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S tests/test_lean_code_gate.py` -> 95 tests passed.
- `python3 -B -S lean-code-gate-v3/.agent/lean/lean_code_gate.py check --repo "/home/prop_/projects/lean-code/gate" --json` -> ok true.
- `PYTHONDONTWRITEBYTECODE=1 python3 /home/prop_/.codex/skills/production-code/scripts/code_quality_gate.py check --repo "/home/prop_/projects/lean-code/gate"` -> pass.
- `printf '{"cwd":"/home/prop_"}' | timeout 5s python3 -B -S /home/prop_/projects/lean-code/gate/lean-code-gate-v3/.agent/lean/lean_code_gate.py stop` -> exit_code=0.
- `printf '{"cwd":"/home/prop_/projects/lean-code/gate"}' | timeout 5s python3 -B -S /home/prop_/projects/lean-code/gate/lean-code-gate-v3/.agent/lean/lean_code_gate.py stop` -> exit_code=0.
- `git diff --check` -> pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pathless tool operations now prefer a previously remembered nested target when valid, still blocking hidden writes; stop-root detection prefers the remembered nested repo for git controllers and returns no stop roots for non-git controllers.

* **New Features**
  * Remembered nested-target validation improves selection behavior for ambiguous/missing paths.
  * Session updates now merge only when session IDs match, updating turn IDs, prompt hashes, and timestamps while preserving other state.

* **Tests**
  * Added coverage for remembered-target behavior, path-bearing vs pathless resolution, stop-root handling, and non-git controller behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->