### PR TITLE
[codex] Document lean gate challenge architecture

### DIFF
--- a/lean-code-gate-v3/LEAN_CODE_GATE_V3_REWARD_LAYER_v1.4.md
+++ b/lean-code-gate-v3/LEAN_CODE_GATE_V3_REWARD_LAYER_v1.4.md
@@ -91,7 +91,7 @@ The prototype should be evaluated as a behavior-shaping challenge layer before i
 
 Markdown standards decay during long editing loops. A deterministic Stop-time challenge should reduce sloppy final diffs by forcing one more lean pass when the code is correct but still bloated, duplicative, weakly verified, or near its declared budget.
 
-The reasoning layer can add a second, semantic challenge signal before any true reward-model work. In the Property Partner Ops workflow, Repo Context Forge fixes the initial surface, GitNexus checks graph impact, and Claude Advisor then acts as a consolidated read-only challenger before preflight and again before commit. This can replace or supplement sub-agent delegation without making Lean Gate itself depend on another model.
+The reasoning layer can add a second, semantic challenge signal before any true reward-model work. In the Property Partner Ops workflow, Repo Context Forge fixes the initial surface, GitNexus checks graph impact, and Claude Advisor then acts as a consolidated read-only challenger before preflight and again before commit. The current advisor shape is **CASS: Claude Advisor Stable Sessions**. CASS uses a stable semantic session slug, keeps phase as metadata, and keeps phase-specific prompt packaging outside Lean Gate.
 
 ### Phase 1: challenge layer
 
@@ -132,29 +132,16 @@ Useful metrics:
 
 ### Advisor challenge signal
 
-Claude Advisor should be modeled as an external semantic challenge event, not a deterministic rule result. It is useful because it can challenge issue interpretation, slice ownership, architecture fit, TDD proof, no-change surfaces, and reviewer coverage in ways the deterministic gate should not infer.
+Claude Advisor is external semantic advice, not a Lean Gate event stream and not a deterministic rule result. It is useful because it can challenge issue interpretation, slice ownership, architecture fit, TDD proof, no-change surfaces, reviewer coverage, and whether the code deepens the owning module instead of creating shallow helper/service/wrapper splits.
 
-Example event:
+Current CASS contract:
 
-```json
-{
-  "event": "advisor_challenge",
-  "source": "claude-advisor",
-  "phase": "pre-commit",
-  "verdict": "fix-before-commit",
-  "focus": ["minimality", "tdd", "regression-risk"],
-  "codex_judgment": "accepted",
-  "followup_mutation": true
-}
-```
-
-Rules:
-
-- Do not call Claude from Lean Gate hooks.
-- Do not block deterministic Stop success solely because Claude is unavailable.
-- Record advisor verdict, phase, focus tags, Codex judgment, and whether a follow-up mutation happened.
-- Treat advisor output as evidence to validate against code, tests, GitNexus, reviewer text, and deterministic gate results.
-- Use advisor agreement with later human review as an evaluation signal for future reward-model work.
+- `preflight-advice` runs after Repo Context Forge and packet-scoped GitNexus, before production preflight and edits. Its evidence package must explicitly name the Repo Context Forge packet target surface and coverage plan, plus packet-scoped GitNexus findings.
+- `precommit-challenge` runs after Codex has made and verified the code changes, before commit/push. It challenges the live diff, TDD proof, reviewer/PRD coverage, module shape, minimality, and no-change surfaces.
+- Freeform advisor calls stay freeform. The precommit verdict/action shape belongs only to the `precommit-challenge` phase, and the preflight evidence checklist belongs only to `preflight-advice`.
+- Stable verdicts or focus tags may be useful as optional local summaries, but they must not restrict what Claude can say, become hook inputs, or weaken the semantic advice signal.
+- Lean Gate v1.4 does not log advisor events, parse advisor verdicts, or block deterministic Stop success because Claude is unavailable.
+- Treat advisor output as evidence for Codex to validate against code, tests, GitNexus, reviewer text, and deterministic gate results.
 
 ### Phase 3: evaluation dataset
 

--- a/lean-code-gate-v3/LEAN_CODE_GATE_V3_REWARD_LAYER_v1.4.md
+++ b/lean-code-gate-v3/LEAN_CODE_GATE_V3_REWARD_LAYER_v1.4.md
@@ -14,6 +14,8 @@ This v1.4 design implements the reward layer inside `.agent/lean/lean_code_gate.
 
 The implementation target is production feedback for LLM coding agents: reward small correct diffs, reuse existing code, punish fake-green shortcuts, never trade correctness for brevity, and keep every signal deterministic.
 
+Architectural stance: the near-term product is a **challenge layer**, not a genuine ML reward model. The challenge layer counters instruction drift after long edits by reasserting the lean-production standard at Stop time, after correctness checks pass but before the agent declares completion. A genuine ML reward layer can come later only if logged challenge outcomes prove that the deterministic score correlates with accepted, production-quality code.
+
 
 v1.4 keeps the v1.1 corrections: `specific_next_action()` ranks reuse and bloat suggestions by expected leanness gain rather than fixed rule order, and event ordering treats wall-clock time as best-effort while preserving deterministic append-chain order.
 
@@ -80,6 +82,110 @@ Important correction to the previous draft:
 13. **No bounded reward history.** Prior scores, challenge counts, and leaderboard aggregation must read all relevant score events, not just the last 200 JSONL lines.
 14. **No unsupported chain platform.** If `reward_chain_enabled=true` and the runtime has no supported file-lock implementation, the hook/CLI must reject the configuration with an actionable message before writing.
 15. **No Windows sidecar artifacts.** `*:Zone.Identifier` files must be excluded from repo commits, generated artifacts, and release packages.
+
+## Evaluation strategy
+
+The prototype should be evaluated as a behavior-shaping challenge layer before it is treated as a reward model.
+
+### Hypothesis
+
+Markdown standards decay during long editing loops. A deterministic Stop-time challenge should reduce sloppy final diffs by forcing one more lean pass when the code is correct but still bloated, duplicative, weakly verified, or near its declared budget.
+
+The reasoning layer can add a second, semantic challenge signal before any true reward-model work. In the Property Partner Ops workflow, Repo Context Forge fixes the initial surface, GitNexus checks graph impact, and Claude Advisor then acts as a consolidated read-only challenger before preflight and again before commit. This can replace or supplement sub-agent delegation without making Lean Gate itself depend on another model.
+
+### Phase 1: challenge layer
+
+Goal: improve the final diff inside the current session.
+
+- Keep challenge mode opt-in and repo-local.
+- Challenge only after final correctness and quality gates pass.
+- Emit one concrete next action, not a list of coaching advice.
+- Cap challenge loops per contract.
+- Allow correctness to win after the cap; preserve the low score in telemetry instead of trapping the agent.
+- Keep Claude Advisor outside the hook hot path. When used, call it from the delivery workflow after GitNexus and before preflight, then again before commit for non-trivial diffs.
+
+Success signals:
+
+- challenged attempts usually shrink added/changed lines or remove duplicate/reuse findings on the next pass
+- no increase in failed tests, missing verification, or out-of-scope edits after a challenge
+- low false-positive rate from human review of challenge denials
+- agents complete within the challenge cap without needing manual escape hatches
+
+### Phase 2: reward telemetry
+
+Goal: measure whether challenge feedback is useful before it blocks more broadly.
+
+- Log score, verdict, critique, delta, budget usage, quality counts, and challenge count.
+- Compare pre-challenge and post-challenge attempts for the same contract.
+- Track whether human reviewers accepted the final diff without lean-code comments.
+- Keep the score observational by default; do not rank agents operationally from early data.
+
+Useful metrics:
+
+- challenge improvement rate
+- average added/changed-line reduction after challenge
+- duplicate/reuse/bloat finding resolution rate
+- verification preservation rate
+- human-review agreement with the challenge outcome
+- false challenge rate
+- advisor agreement rate with Lean Gate and human review
+
+### Advisor challenge signal
+
+Claude Advisor should be modeled as an external semantic challenge event, not a deterministic rule result. It is useful because it can challenge issue interpretation, slice ownership, architecture fit, TDD proof, no-change surfaces, and reviewer coverage in ways the deterministic gate should not infer.
+
+Example event:
+
+```json
+{
+  "event": "advisor_challenge",
+  "source": "claude-advisor",
+  "phase": "pre-commit",
+  "verdict": "fix-before-commit",
+  "focus": ["minimality", "tdd", "regression-risk"],
+  "codex_judgment": "accepted",
+  "followup_mutation": true
+}
+```
+
+Rules:
+
+- Do not call Claude from Lean Gate hooks.
+- Do not block deterministic Stop success solely because Claude is unavailable.
+- Record advisor verdict, phase, focus tags, Codex judgment, and whether a follow-up mutation happened.
+- Treat advisor output as evidence to validate against code, tests, GitNexus, reviewer text, and deterministic gate results.
+- Use advisor agreement with later human review as an evaluation signal for future reward-model work.
+
+### Phase 3: evaluation dataset
+
+Goal: build a dataset that can later support model or prompt evaluation.
+
+Each accepted/rejected attempt should be linkable to:
+
+- prompt or task summary
+- Lean Change Contract
+- pre-challenge diff summary
+- post-challenge diff summary when present
+- verification outcomes
+- gate findings and reward signal
+- advisor challenge event and Codex judgment when present
+- human review outcome or merge outcome when available
+
+Do not store secrets, full environment dumps, raw remote URLs, or unnecessary command output in the reward event. If richer training data is needed, store it in an explicit offline evaluation artifact, not the Stop-hook hot path.
+
+### Phase 4: ML reward model candidate
+
+A genuine ML reward model is only justified after deterministic telemetry has enough reviewed examples to prove predictive value.
+
+Use gate output as features, not as ground truth. The target label should come from accepted/rejected review outcomes, human lean-code judgments, or production-quality outcomes. The deterministic score can seed the dataset, but it must not become the only definition of quality.
+
+Minimum bar before ML work:
+
+- enough examples across multiple repos and task types
+- measured correlation between score/challenge result and human acceptance
+- known false-positive families documented and reduced
+- no evidence that agents improve the score by weakening tests, over-declaring budgets, or avoiding necessary code
+- stable rule IDs so model features do not shift under the dataset
 
 ## Implementation summary
 

--- a/lean-code-gate-v3/LEAN_GATE_MODULAR_RULE_BLUEPRINT.md
+++ b/lean-code-gate-v3/LEAN_GATE_MODULAR_RULE_BLUEPRINT.md
@@ -16,7 +16,15 @@ lean-code-gate            -> contract storage, hook enforcement, rule reporting
 
 Lean Gate should block deterministic violations. Skills should explain how to reason through the work and recover correctly.
 
-Claude Advisor belongs in the reasoning layer, not the deterministic gate core. It can replace or supplement sub-agent delegation as a consolidated read-only challenger after Repo Context Forge and GitNexus have fixed the surface. Lean Gate may record externally supplied advisor events later, but hooks must not call Claude, GitNexus, Repo Context Forge, or any LLM-dependent process.
+Claude Advisor belongs in the reasoning layer, not the deterministic gate core. CASS, the current Claude Advisor Stable Sessions design, keeps one stable semantic session slug and treats `preflight-advice` and `precommit-challenge` as prompt phases. Hooks must not call Claude, GitNexus, Repo Context Forge, or any LLM-dependent process.
+
+Advisor phase boundary:
+
+- `preflight-advice`: after Repo Context Forge and packet-scoped GitNexus, before production preflight and edits; the prompt package must preserve the exact Repo Context Forge packet target surface, coverage plan, and packet-scoped GitNexus findings.
+- `precommit-challenge`: after code edits and verification, before commit/push; the prompt package challenges the live diff, TDD proof, reviewer/PRD coverage, module shape, minimality, regression risk, and next action.
+- Freeform advisor calls are not forced into either rubric.
+- Stable verdicts and focus tags may help local summaries later, but they are not Lean Gate rule IDs, hook inputs, or constraints on Claude's advice.
+- Lean Gate should not log advisor events in this plan. If future evaluation needs advisor telemetry, add it as an explicit offline evaluation artifact, not in hook enforcement.
 
 ## Target Module Shape
 
@@ -268,4 +276,4 @@ Avoid mixed modes that make root and state resolution ambiguous. Do not hard-cod
 
 Lean Gate must stay deterministic. Skill references explain recovery, but hard blocks should not depend on LLM judgment.
 
-Advisor output is evidence for Codex to validate, not a rule result. If future telemetry records advisor verdicts, store them as separate challenge events and keep deterministic rule failures independent of advisor availability, auth state, model output, or network state.
+Advisor output is evidence for Codex to validate, not a rule result. Deterministic rule failures stay independent of advisor availability, auth state, model output, network state, verdict tags, and focus tags.

--- a/lean-code-gate-v3/LEAN_GATE_MODULAR_RULE_BLUEPRINT.md
+++ b/lean-code-gate-v3/LEAN_GATE_MODULAR_RULE_BLUEPRINT.md
@@ -1,0 +1,271 @@
+# Lean Gate Modular Rule Blueprint
+
+## Objective
+
+Turn Lean Code Gate into a deterministic enforcement engine while keeping the existing skills as the reasoning layer.
+
+```text
+repo-context-forge       -> target-surface intake and coverage plan
+gitnexus                 -> graph impact, callers, contracts, blast radius
+claude-advisor           -> read-only semantic challenge before preflight and before commit
+production-preflight      -> edit-boundary reasoning
+test-driven-development   -> behavior proof
+production-code           -> quality standard and final judgment
+lean-code-gate            -> contract storage, hook enforcement, rule reporting
+```
+
+Lean Gate should block deterministic violations. Skills should explain how to reason through the work and recover correctly.
+
+Claude Advisor belongs in the reasoning layer, not the deterministic gate core. It can replace or supplement sub-agent delegation as a consolidated read-only challenger after Repo Context Forge and GitNexus have fixed the surface. Lean Gate may record externally supplied advisor events later, but hooks must not call Claude, GitNexus, Repo Context Forge, or any LLM-dependent process.
+
+## Target Module Shape
+
+```text
+.agent/lean/
+  lean_code_gate.py
+  lean_gate/
+    cli.py
+    hooks.py
+    contracts.py
+    state.py
+    repo.py
+    mutation.py
+    verification.py
+    policy.py
+    output.py
+    rules/
+      catalog.py
+      results.py
+    quality/
+      runner.py
+      escapes.py
+      bloat.py
+      duplicate.py
+      reuse.py
+      symbols.py
+      advisory.py
+```
+
+Responsibilities:
+
+- `lean_code_gate.py`: thin entrypoint only.
+- `cli.py`: command parsing and dispatch.
+- `hooks.py`: session, pretool, posttool, permission, and stop handlers.
+- `contracts.py`: declare, validate, widen, and contract identity checks.
+- `state.py`: repo-local state, event log, contract persistence.
+- `repo.py`: root, worktree, nested repo, and global-script resolution.
+- `mutation.py`: mutating-tool detection, scope checks, budget checks, hidden-write checks.
+- `verification.py`: verify-command recognition and pass/fail accounting.
+- `policy.py`: baseline defaults plus repo policy merge.
+- `output.py`: stable human and JSON hook output.
+- `rules/catalog.py`: stable rule IDs, messages, remediation, skill references, examples.
+- `rules/results.py`: `RuleResult` data model and helpers.
+- `quality/*`: changed-scope quality scanners.
+
+## Rule Catalog
+
+Every blocker and warning should come from a stable rule ID. Do not scatter one-off error strings through hook logic.
+
+```python
+RULES = {
+    "contract.missing": {
+        "severity": "block",
+        "skill": "lean-code",
+        "skillSection": "Minimal preflight for micro-fixes",
+        "message": "No active Lean Change Contract.",
+        "remediation": "Declare a minimal or full contract before editing.",
+    },
+    "proof.tdd_missing": {
+        "severity": "block",
+        "skill": "test-driven-development",
+        "skillSection": "RED-GREEN-REFACTOR",
+        "message": "Code work proof plan does not name a TDD feedback loop.",
+        "remediation": "Add a failing behavior or regression test first, or declare an approved exception.",
+    },
+    "quality.fake_green": {
+        "severity": "block",
+        "skill": "production-code",
+        "skillSection": "Non-Negotiable Rules",
+        "message": "Changed source contains a fake-green suppression.",
+        "remediation": "Remove the suppression and fix the underlying failure.",
+    },
+}
+```
+
+## Rule Result Shape
+
+Use one structured result shape everywhere.
+
+```json
+{
+  "ruleId": "contract.missing",
+  "severity": "block",
+  "phase": "PreToolUse",
+  "message": "No active Lean Change Contract.",
+  "skill": "lean-code",
+  "skillSection": "Minimal preflight for micro-fixes",
+  "remediation": "Declare a minimal or full contract before editing.",
+  "exampleCommand": "python3 -B -S .agent/lean/lean_code_gate.py declare --minimal-preflight ..."
+}
+```
+
+The hook output should be self-contained enough for an agent to recover immediately. The skill reference is supporting context, not the only instruction.
+
+## Human Hook Output
+
+Example:
+
+```text
+Lean Code Gate blocked mutation.
+
+Rule: contract.missing
+Skill: lean-code -> Minimal preflight for micro-fixes
+Fix: Declare a minimal or full contract before editing.
+
+Example:
+python3 -B -S .agent/lean/lean_code_gate.py declare --minimal-preflight \
+  --intent "fix exact bug" \
+  --scope "src/file.py,tests/test_file.py" \
+  --task-type bugfix \
+  --verify "pytest tests/test_file.py"
+```
+
+## Skill Routing
+
+Map failures to the skill that tells the agent how to recover:
+
+| Failure | Rule Example | Skill |
+|---|---|---|
+| Missing contract | `contract.missing` | `lean-code` |
+| Missing affected surface, contract, risk, or reuse path | `contract.preflight_field_missing` | `production-preflight` |
+| Missing TDD loop or failed verification | `proof.tdd_missing`, `verification.failed` | `test-driven-development` |
+| Fake green, TODO, duplicate helper, bloat, type escape | `quality.*` | `production-code` |
+| Out-of-scope mutation or oversized diff | `mutation.*` | `production-preflight` plus `lean-code` |
+
+## Preflight To Contract Bridge
+
+A compact `production-preflight` output can map directly to a Lean contract.
+
+Preflight:
+
+```md
+`scope`: src/search.ts, tests/search.test.ts
+`contract`: path-like searches return real clickable file results
+`approach`: extend existing path parser, no new search backend
+`proof`: red-green-refactor: npm test -- search.test.ts
+`touchpoints`: src/search.ts, tests/search.test.ts
+`risksAndQuestions`: none
+```
+
+Generated Lean declaration:
+
+```bash
+python3 -B -S .agent/lean/lean_code_gate.py declare \
+  --intent "fix path search for clickable file results" \
+  --scope "src/search.ts,tests/search.test.ts" \
+  --task-type bugfix \
+  --affected-surface "path search and result opening flow" \
+  --authoritative-contract "path-like searches return real clickable files" \
+  --invariant "normal filename search still works" \
+  --reuse-path "existing path parser/search adapter" \
+  --proof-plan "red-green-refactor: npm test -- search.test.ts" \
+  --risk-check "avoid introducing a second search path" \
+  --verify "npm test -- search.test.ts"
+```
+
+## Failure Examples
+
+Out-of-scope edit:
+
+```json
+{
+  "ruleId": "mutation.out_of_scope",
+  "skill": "production-preflight",
+  "message": "Edit touches src/newSearch.ts outside declared scope.",
+  "remediation": "Keep the change inside scope or redeclare with --widen and a concrete reason."
+}
+```
+
+Missing verification:
+
+```json
+{
+  "ruleId": "verification.missing_after_mutation",
+  "skill": "test-driven-development",
+  "message": "Mutation occurred but the declared verify command has not passed.",
+  "remediation": "Run the declared verification command and fix failures before completion."
+}
+```
+
+Fake green:
+
+```json
+{
+  "ruleId": "quality.fake_green",
+  "skill": "production-code",
+  "message": "Changed source contains '|| true'.",
+  "remediation": "Remove the bypass and make the command fail honestly."
+}
+```
+
+## Policy Layers
+
+Policy should resolve in this order:
+
+1. Baseline defaults.
+2. Repo-local `.agent/lean/policy.json`.
+3. Branch or CI policy overrides.
+4. Declared contract exceptions with evidence.
+
+Exceptions should require a reason and should stay visible in the active contract.
+
+## Hard Fail Discipline
+
+Keep hard blocks for deterministic issues:
+
+- missing or invalid contract
+- out-of-scope mutation
+- hidden file-changing Bash without declaration
+- missing or failed declared verification
+- fake-green suppressions
+- new files or dependency changes without declaration
+- oversized diff beyond contract budget
+- merge conflict markers and temporary artifacts
+
+Keep heuristic detectors as warnings unless confidence is high enough to be deterministic in changed scope.
+
+## Stop Report Shape
+
+Final stop output should group issues by:
+
+- contract errors
+- scope and budget errors
+- verification errors
+- quality errors
+- warnings
+
+This makes the recovery path obvious and avoids one long mixed error string.
+
+## Install Modes
+
+Support two explicit modes:
+
+- Repo-local install: script and state live under the target repo at `.agent/lean/`.
+- Global script install: shared script path, repo-local state under the target repo.
+
+Avoid mixed modes that make root and state resolution ambiguous. Do not hard-code a global `LEAN_CODE_GATE_REPO_ROOT` unless the runtime cannot provide a working directory.
+
+## Implementation Order
+
+1. Extract `rules/catalog.py` and route existing blocker/warning strings through rule IDs.
+2. Add `RuleResult` and centralized `output.py`.
+3. Split contract, state, repo, and hook logic without changing behavior.
+4. Split quality checks into `quality/*`.
+5. Add tests asserting each blocker emits the correct `ruleId`, skill, remediation, and example.
+6. Add the preflight-to-contract helper after extraction is stable.
+
+## Design Constraint
+
+Lean Gate must stay deterministic. Skill references explain recovery, but hard blocks should not depend on LLM judgment.
+
+Advisor output is evidence for Codex to validate, not a rule result. If future telemetry records advisor verdicts, store them as separate challenge events and keep deterministic rule failures independent of advisor availability, auth state, model output, or network state.


### PR DESCRIPTION
## Summary

- add a modular Lean Gate rule blueprint covering deterministic rule IDs, structured remediation, install modes, and the boundary between reasoning skills and gate internals
- update the reward-layer plan to frame the near-term product as a challenge layer before any ML reward model
- add Claude Advisor as an external semantic challenge signal for evaluation, while keeping Lean Gate hooks deterministic

## Validation

- git diff --cached --check
- reviewed staged doc diff before commit

## Notes

The working tree still has unrelated pre-existing local edits in lean-code-gate-v3/.agent/lean/lean_code_gate.py and lean-code-gate-v3/tests/test_lean_code_gate.py; they are not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the reward layer as a deterministic challenge-style mechanism for post-check enforcement and added a phased evaluation strategy (challenge, telemetry, dataset linkage, gating criteria).
  * Added a modular Lean Gate blueprint: deterministic rule-catalog, unified rule result shape, advisor boundary separating deterministic enforcement from advisory phases, skill-routing, policy layering, hard-fail discipline, sample payloads, and install/implementation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->