### PR TITLE
Harden widen after rejected mutation

### DIFF
--- a/lean-code-gate-v3/.agent/lean/lean_code_gate.py
+++ b/lean-code-gate-v3/.agent/lean/lean_code_gate.py
@@ -750,11 +750,6 @@ def contract(root: Path) -> dict[str, object]:
     return loaded if isinstance(loaded, dict) else {}
 
 
-def contract_snapshot(root: Path) -> dict[str, object]:
-    loaded = read_json(root / STATE_DIR / "contract.json", {})
-    return loaded if isinstance(loaded, dict) else {}
-
-
 def log_event(root: Path, event: dict[str, object]) -> None:
     item = {"time": time.time(), **event}
     with events_path(root).open("a", encoding="utf-8") as file:
@@ -775,6 +770,8 @@ def events(root: Path, limit: int = 200) -> list[dict[str, object]]:
             out.append(value)
     return out
 
+def stop_and_redesign_errors(errors: list[str]) -> bool:
+    return any(any(marker in error for marker in ("Adds about ", "Changes about ", "Touches ", "Possible abstraction bloat", "quality escapes")) for error in errors)
 
 def hook_input() -> dict[str, object]:
     raw = sys.stdin.read()
@@ -1475,31 +1472,6 @@ def same_pass_through_args(args: str, call_args: str) -> bool:
     return argument_names(args, declaration=True) == argument_names(call_args, declaration=False)
 
 
-def scan_verification_mode(ctx: GateContext, current_contract: dict[str, object], active_policy: dict[str, object]) -> list[dict[str, object]]:
-    if not current_contract or minimal_preflight(current_contract):
-        return []
-    task_type = str(current_contract.get("task_type") or "unknown")
-    if not code_task(task_type):
-        return []
-    changed = [path for path in sorted(ctx.changed_files) if not internal_gate_path(path)]
-    if not any(path_type(path) == "prod" and is_source_path(path) for path in changed):
-        return []
-    tokens = verification_mode_tokens(active_policy)
-    if proof_plan_has_verification_mode(current_contract.get("proof_plan"), tokens):
-        return []
-    return [
-        advisory_finding(
-            "verification-mode",
-            "verification",
-            f"{STATE_DIR}/contract.json",
-            0,
-            "warning",
-            "full code work proof_plan must name an explicit verification feedback loop",
-            "proof_plan lacks one of: " + ", ".join(tokens),
-        )
-    ]
-
-
 def verification_mode_tokens(active_policy: dict[str, object]) -> tuple[str, ...]:
     raw = active_policy.get("verification_mode_tokens")
     if not isinstance(raw, list):
@@ -2136,7 +2108,6 @@ def run_quality_gate(repo: Path, base_ref: str | None, fail_on_warnings: bool) -
     advisory_groups["securityAssumptionFindings"]["added"].extend(scan_sensitive_input(ctx))
     advisory_groups["slopShapeFindings"]["added"].extend(scan_failure_contract(ctx))
     advisory_groups["slopShapeFindings"]["added"].extend(scan_wrapper_value(ctx))
-    advisory_groups["verificationShapeFindings"]["added"].extend(scan_verification_mode(ctx, contract_snapshot(repo), active_policy))
     advisory_groups["verificationShapeFindings"]["added"].extend(scan_production_shaped_proof(ctx))
     apply_advisory_delta(ctx, advisory_groups)
 
@@ -2404,6 +2375,10 @@ def contract_errors(current_contract: dict[str, object], active_policy: dict[str
         for field, flag in required_fields:
             if not meaningful(current_contract.get(field)):
                 errors.append(f"Code work requires {flag}.")
+        proof_text = " ".join(str(item) for key in ("proof_plan", "verify") for item in (current_contract.get(key) if isinstance(current_contract.get(key), list) else [current_contract.get(key) or ""])).lower()
+        tokens = tuple(token for token in verification_mode_tokens(active_policy) if token != "smoke-check" or not re.search(r"\b(pytest|unittest|nose|tox|jest|vitest|mocha|go test|cargo test|npm test|pnpm test|yarn test)\b", proof_text))
+        if meaningful(current_contract.get("proof_plan")) and not proof_plan_has_verification_mode(current_contract.get("proof_plan"), tokens):
+            errors.append("Code work proof_plan must name a TDD feedback loop: " + ", ".join(tokens) + ".")
     if active_policy["require_reuse_path_for_code"] and task_type in {"bugfix", "feature", "refactor"}:
         if not meaningful(current_contract.get("reuse_path")) and not meaningful(current_contract.get("no_reuse_reason")):
             errors.append("Code work requires --reuse-path naming the existing path to extend, or --no-reuse-reason with evidence.")
@@ -2540,6 +2515,15 @@ def declare(args: argparse.Namespace) -> None:
     if args.widen and not args.reason:
         print("Widening requires --reason.", file=sys.stderr)
         raise SystemExit(2)
+    if args.widen and old:
+        declared_at = float(old.get("declared_at", 0))
+        if any(event.get("event") == "mutation_rejected" and float(event.get("time", 0)) >= declared_at for event in events(root, limit=1000000)):
+            print(
+                "Lean Change Contract rejected:\n- Previous gate rejection is a stop-and-redesign event; "
+                "do not bypass it with --widen. Start a fresh contract after reducing the diff.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
     preflight_level = "minimal" if args.minimal_preflight else "full"
     default_max_files = active_policy["minimal_preflight_max_files"] if args.minimal_preflight else active_policy["default_max_files"]
     default_max_added = active_policy["minimal_preflight_max_added_lines"] if args.minimal_preflight else active_policy["default_max_added_lines"]
@@ -2614,6 +2598,8 @@ def pretool(payload: dict[str, object]) -> None:
     change_facts = hook_facts(payload, root, tool, tool_input)
     errors = check_change(change_facts, current_contract, active_policy, tool)
     if errors:
+        if stop_and_redesign_errors(errors):
+            log_event(root, {"event": "mutation_rejected", "tool": tool, **{key: change_facts[key] for key in ("paths", "added", "deleted")}})
         deny("PreToolUse", "Lean Code Gate blocked over-broad or low-quality mutation:\n- " + "\n- ".join(errors))
         return
     remember_target_root(payload, root)

--- a/lean-code-gate-v3/tests/test_lean_code_gate.py
+++ b/lean-code-gate-v3/tests/test_lean_code_gate.py
@@ -82,10 +82,8 @@ def init_repo_fixture(repo: Path) -> None:
     git(repo, "commit", "--no-gpg-sign", "-m", "init")
 
 
-def declare_valid(repo: Path, *, task_type: str = "feature", scope: str = "src/app.py,tests/test_app.py") -> None:
-    result = run_gate(
-        repo,
-        "declare",
+def valid_contract_args(task_type: str = "feature", scope: str = "src/app.py,tests/test_app.py") -> tuple[str, ...]:
+    return (
         "--intent",
         "adjust add behavior",
         "--scope",
@@ -101,12 +99,16 @@ def declare_valid(repo: Path, *, task_type: str = "feature", scope: str = "src/a
         "--reuse-path",
         "src/app.py add function",
         "--proof-plan",
-        "pytest tests/test_app.py",
+        "red-green-refactor: pytest tests/test_app.py",
         "--risk-check",
         "addition behavior regression",
         "--verify",
         "pytest tests/test_app.py",
     )
+
+
+def declare_valid(repo: Path, *, task_type: str = "feature", scope: str = "src/app.py,tests/test_app.py") -> None:
+    result = run_gate(repo, "declare", *valid_contract_args(task_type, scope))
     assert result.returncode == 0, result.stderr
 
 
@@ -127,8 +129,8 @@ def declare_minimal(repo: Path) -> None:
     assert result.returncode == 0, result.stderr
 
 
-def declare_full_with_proof_plan(repo: Path, proof_plan: str, *, task_type: str = "feature", scope: str = "src/app.py") -> None:
-    result = run_gate(
+def declare_full_with_proof_plan_result(repo: Path, proof_plan: str, *, task_type: str = "feature", scope: str = "src/app.py") -> subprocess.CompletedProcess[str]:
+    return run_gate(
         repo,
         "declare",
         "--intent",
@@ -152,6 +154,10 @@ def declare_full_with_proof_plan(repo: Path, proof_plan: str, *, task_type: str 
         "--verify",
         "pytest tests/test_app.py",
     )
+
+
+def declare_full_with_proof_plan(repo: Path, proof_plan: str, *, task_type: str = "feature", scope: str = "src/app.py") -> None:
+    result = declare_full_with_proof_plan_result(repo, proof_plan, task_type=task_type, scope=scope)
     assert result.returncode == 0, result.stderr
 
 
@@ -640,27 +646,30 @@ def test_wrapper_value_uses_existing_marker_comments_on_tracked_files() -> None:
         assert [item for item in _advisory_added(data, "slopShapeFindings") if item["rule"] == "wrapper-value"] == []
 
 
-def test_verification_mode_missing_full_code_contract_is_advisory() -> None:
+def test_full_code_contract_requires_tdd_verification_mode() -> None:
     with repo_fixture() as repo:
-        declare_full_with_proof_plan(repo, "pytest tests/test_app.py")
-        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\nVALUE = 1\n", encoding="utf-8")
-        code, data = check_json(repo)
-        findings = _advisory_added(data, "verificationShapeFindings")
-        assert code == 0, data
-        assert len(findings) == 1
-        assert findings[0]["rule"] == "verification-mode"
-        assert "red-green-refactor" in findings[0]["evidence"]
-        assert data["warnings"] == []
+        result = declare_full_with_proof_plan_result(repo, "pytest tests/test_app.py")
+        assert result.returncode == 2
+        assert "TDD" in result.stderr
+        assert "red-green-refactor" in result.stderr
 
 
 def test_verification_mode_tokens_are_accepted_and_negations_rejected() -> None:
-    for token in ("red-green-refactor", "green-refactor-green", "smoke-check"):
+    for token in ("red-green-refactor", "green-refactor-green"):
         with repo_fixture() as repo:
             declare_full_with_proof_plan(repo, f"{token}: pytest tests/test_app.py")
             (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\nVALUE = 1\n", encoding="utf-8")
             code, data = check_json(repo)
             assert code == 0, data
             assert _advisory_added(data, "verificationShapeFindings") == []
+    with repo_fixture() as repo:
+        result = declare_full_with_proof_plan_result(repo, "smoke-check: pytest tests/test_app.py")
+        assert result.returncode == 2
+        assert "red-green-refactor" in result.stderr
+    with repo_fixture() as repo:
+        result = declare_full_with_proof_plan_result(repo, "smoke-check: manual CLI check before edit")
+        assert result.returncode == 2
+        assert "red-green-refactor" in result.stderr
     negated_plans = (
         "not doing red-green-refactor; pytest tests/test_app.py",
         "without any scheduled or planned red-green-refactor; pytest tests/test_app.py",
@@ -673,17 +682,13 @@ def test_verification_mode_tokens_are_accepted_and_negations_rejected() -> None:
     )
     for proof_plan in negated_plans:
         with repo_fixture() as repo:
-            declare_full_with_proof_plan(repo, proof_plan)
-            (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\nVALUE = 1\n", encoding="utf-8")
-            code, data = check_json(repo)
-            assert code == 0, data
-            assert len(_advisory_added(data, "verificationShapeFindings")) == 1
+            result = declare_full_with_proof_plan_result(repo, proof_plan)
+            assert result.returncode == 2
+            assert "red-green-refactor" in result.stderr
     with repo_fixture() as repo:
-        declare_full_with_proof_plan(repo, "no red-green-refactor or smoke-check; pytest tests/test_app.py")
-        (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\nVALUE = 1\n", encoding="utf-8")
-        code, data = check_json(repo)
-        assert code == 0, data
-        assert len(_advisory_added(data, "verificationShapeFindings")) == 1
+        result = declare_full_with_proof_plan_result(repo, "no red-green-refactor or smoke-check; pytest tests/test_app.py")
+        assert result.returncode == 2
+        assert "red-green-refactor" in result.stderr
     with repo_fixture() as repo:
         declare_full_with_proof_plan(repo, "no smoke-check, using red-green-refactor cycle; pytest tests/test_app.py")
         (repo / "src" / "app.py").write_text("def add(a: int, b: int) -> int:\n    return a + b\nVALUE = 1\n", encoding="utf-8")
@@ -1497,7 +1502,7 @@ def test_edit_rewrite_counts_as_changed_lines() -> None:
             "--reuse-path",
             "src/app.py add function",
             "--proof-plan",
-            "pytest tests/test_app.py",
+            "red-green-refactor: pytest tests/test_app.py",
             "--risk-check",
             "line rewrite risk",
             "--verify",
@@ -1554,6 +1559,19 @@ def test_pretool_blocks_fake_green_before_edit() -> None:
         data = json.loads(result.stdout)
         assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert "quality escapes" in data["reason"]
+        with (repo / ".agent" / "lean" / "state" / "events.jsonl").open("a", encoding="utf-8") as file:
+            for index in range(201):
+                file.write(json.dumps({"event": "mutation_allowed", "time": index}) + "\n")
+        widened = run_gate(
+            repo,
+            "declare",
+            "--widen",
+            "--reason",
+            "try larger budget after rejection",
+            *valid_contract_args(),
+        )
+        assert widened.returncode == 2
+        assert "stop-and-redesign" in widened.stderr
 
 
 def test_stop_blocks_quality_escape_in_changed_source() -> None:
@@ -2187,7 +2205,7 @@ TESTS = [
     test_wrapper_value_detects_python_ts_and_go_forwarders,
     test_wrapper_value_markers_and_framework_overrides_do_not_hit,
     test_wrapper_value_uses_existing_marker_comments_on_tracked_files,
-    test_verification_mode_missing_full_code_contract_is_advisory,
+    test_full_code_contract_requires_tdd_verification_mode,
     test_verification_mode_tokens_are_accepted_and_negations_rejected,
     test_verification_mode_policy_tokens_are_configurable,
     test_verification_mode_exempts_minimal_and_test_only_work,


### PR DESCRIPTION
## Summary

- record bloat/quality PreToolUse rejections in existing gate events state
- reject `declare --widen` after a same-contract stop-and-redesign rejection
- require full code contracts to name a TDD feedback loop at declare time
- remove the obsolete verification-mode advisory scanner now covered by declaration validation

Fixes #51.

## Red-Green Evidence

- Red: `tests/test_lean_code_gate.py` failed when `declare --widen` succeeded after a quality-escape PreToolUse rejection.
- Red: `tests/test_lean_code_gate.py` failed when a full code contract with plain `pytest tests/test_app.py` proof was accepted.
- Green: both behaviors now fail closed through the public gate CLI/hook paths.

## Verification

- `cd lean-code-gate-v3 && PYTHONDONTWRITEBYTECODE=1 python3 -B -S tests/test_lean_code_gate.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -S lean-code-gate-v3/.agent/lean/lean_code_gate.py check --repo "$PWD" --json`
- `PYTHONDONTWRITEBYTECODE=1 python3 "$HOME/.codex/skills/production-code/scripts/code_quality_gate.py" check --repo "$PWD"`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks `declare --widen` after a stop-and-redesign rejection and enforces explicit TDD feedback loops in full code contracts. Also removes the obsolete verification-mode advisory scan.

- **Bug Fixes**
  - Record stop-and-redesign PreToolUse failures as `mutation_rejected` events.
  - Reject `declare --widen` if a `mutation_rejected` happened after the last declaration; scans the full event history.

- **Migration**
  - Full code contracts must name a TDD loop in `proof_plan` (e.g., “red-green-refactor” or “green-refactor-green”).
  - “smoke-check” is only allowed for manual checks; plans that run tests must use a TDD token.

<sup>Written for commit 31e706983f24de0f91555422397c5d1e3ac2f89d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Classifies certain pretool blocks as "mutation_rejected" and logs them so rejected mutating attempts are surfaced.

* **Bug Fixes**
  * Disallows widening to bypass prior mutation rejections.
  * Requires meaningful full proof plans to include a verification feedback loop (with explicit exemptions for smoke-check commands).
  * Removes a redundant verification-mode advisory to rely on consolidated verification checks.

* **Tests**
  * Expanded and refactored declare/verification-mode tests to cover new behaviors and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->